### PR TITLE
fix: update snapshot to v2.1.14

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +25,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,3 @@
-stages:
-  - version
-  - build
-  - test
-  - docker
-
 cache:
   key: ${CI_COMMIT_REF_SLUG}
   paths:
@@ -11,7 +5,10 @@ cache:
 
 version:
   image: $ARTIFACTORY_DOCKER_COMMON/node:lts
-  stage: version
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_PIPELINE_SOURCE == "scheduled"
+  needs: [ ]
   artifacts:
     reports:
       dotenv: variables.env
@@ -19,16 +16,16 @@ version:
     - curl -L https://github.com/idc101/git-mkver/releases/download/v1.2.2/git-mkver-linux-amd64-1.2.2.tar.gz | tar xvz
     - mv git-mkver /usr/local/bin
   script:
-    - VERSION=$(git mkver next)
+    - VERSION=$(git mkver next --format '{Docker}')
     - echo $VERSION
     - echo "VERSION=$VERSION" >> variables.env
 
 release-gitlab:
   image: $ARTIFACTORY_DOCKER_COMMON/node:lts
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
   needs:
     - version
-  rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
   before_script:
     - curl --location --output /usr/local/bin/release-cli "https://release-cli-downloads.s3.amazonaws.com/latest/release-cli-linux-amd64"
     - chmod +x /usr/local/bin/release-cli
@@ -41,9 +38,13 @@ release-gitlab:
     tag_name: "v$VERSION"
     ref: "$CI_COMMIT_SHA"
 
-build-prod:
+build:
   image: $ARTIFACTORY_DOCKER_COMMON/node:lts
-  stage: build
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_PIPELINE_SOURCE == "scheduled"
+  needs:
+    - version
   artifacts:
     paths:
       - dist
@@ -53,24 +54,31 @@ build-prod:
 
 lint:
   image: $ARTIFACTORY_DOCKER_COMMON/node:lts
-  stage: test
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_PIPELINE_SOURCE == "scheduled"
+  needs: [ ]
   script:
     - npm ci --cache .npm --prefer-offline
     - npm run lint
 
 audit:
   image: $ARTIFACTORY_DOCKER_COMMON/node:lts
-  stage: test
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_PIPELINE_SOURCE == "scheduled"
+  needs: [ ]
   script:
     - npm ci --cache .npm --prefer-offline
     - npm audit --omit=dev
 
 e2e:
-  image:
-    name: $ARTIFACTORY_DOCKER_COMMON/cypress/included:10.10.0
+  image: $ARTIFACTORY_DOCKER_COMMON/cypress/included:10.10.0
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_PIPELINE_SOURCE == "scheduled"
   needs:
-    - build-prod
-  stage: test
+    - build
   script:
     - npm ci --cache .npm --prefer-offline
     - npm run cy-verify
@@ -78,11 +86,11 @@ e2e:
 
 docker-build-and-release:
   image: $ARTIFACTORY_SERVICE_IMAGES_URL/buildah
-  stage: docker
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_PIPELINE_SOURCE == "push"
+  needs:
+    - version
   script:
-    # Patch for correct docker.io mirror:
     - sed -i "s/docker\.io/$ARTIFACTORY_DOCKER_COMMON/g" Dockerfile
-    - buildah bud --creds ${DOCKER_DEV_USER}:${DOCKER_DEV_PASSWORD} -t ${DOCKER_DEV_URL}/${DOCKER_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA}
-    - buildah push --creds ${DOCKER_DEV_USER}:${DOCKER_DEV_PASSWORD} ${DOCKER_DEV_URL}/${DOCKER_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA}
+    - buildah bud --creds ${DOCKER_DEV_USER}:${DOCKER_DEV_PASSWORD} -t ${DOCKER_DEV_URL}/${DOCKER_IMAGE_NAME}:${VERSION}
+    - buildah push --creds ${DOCKER_DEV_USER}:${DOCKER_DEV_PASSWORD} ${DOCKER_DEV_URL}/${DOCKER_IMAGE_NAME}:${VERSION}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Welcome to the repos of Terminfinder
 
-Currently it is not possible for us to accept merge requests.
+Currently, it is not possible for us to accept merge requests.
 
 You can write issues if you want to.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/node:lts-alpine as build
+FROM docker.io/node:18.13.0 as build
 WORKDIR /app
 
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Terminfinder-SH (Frontend)
 
+https://img.shields.io/github/license/Dataport/terminfinder-frontend
+
 Digital polls from Northern Germany - made by Dataport and the state of Schleswig-Holstein
 
 The "Terminfinder" offers a fast and easy way to create digital polls.
@@ -7,6 +9,8 @@ The "Terminfinder" offers a fast and easy way to create digital polls.
 **Digitale Abstimmungen aus dem Norden - ein Angebot von Dataport und dem Land Schleswig-Holstein**
 
 Mit dem Terminfinder können Sie schnell und einfach digitale Abstimmungen für Gruppen realisieren.
+
+[SECURITY.md](./SECURITY.md)
 
 ## Beschreibung
 
@@ -39,7 +43,7 @@ Beispiel: ```export TITLE='Terminfinder-SH' API_URL='https://test.de/api' EMAIL=
 
 | env-variable                     | docker* | type                     | default                                | description                                                           |
 |----------------------------------|---------|--------------------------|----------------------------------------|-----------------------------------------------------------------------|
-| TITLE                            | ja      | `string`                 | ''                                     | Headline, <title>                                                     |
+| TITLE                            | ja      | `string`                 | ''                                     | Headline                                                              |
 | LOCALE                           | ja      | `'de-DE'` or `'en-EN'`   | `'de-DE'`                              | Initiale Sprache, bis User die Sprache ändert                         |
 | ADDRESSING (used on german only) | ja      | `'du'` or `'sie'`        | `'du'`                                 | Wird der User geduzt oder gesiezt. Nicht vom User anpassbar.          |
 | API_URL                          | ja      | `string` (url)           | ''                                     | URL des Backends. Bei keinem Wert wird die aktuelle URL verwendet     |
@@ -59,6 +63,10 @@ Beispiel: ```export TITLE='Terminfinder-SH' API_URL='https://test.de/api' EMAIL=
 z.B. `@TITLE@` hinterlegt, um zur Laufzeit des Containers ersetzt zu werden. (docker-replace-parameters.sh)
 
 ## Development
+
+[contributing](./CONTRIBUTING.md)
+
+[contributor-agreement](./CONTRIBUTOR-AGREEMENT.md)
 
 ### install and run
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a vulnerability in this software, you can email us at: dataportdabstimmbox@dataport.de
+
+We will get back to you as soon as possible. We will be happy to discuss whether and how you can be named as the
+discoverer of the vulnerability.
+
+## Melden einer Schwachstelle
+
+Um eine Schwachstelle in dieser Software zu melden, können Sie uns eine E-Mail senden an:
+dataportdabstimmbox@dataport.de
+
+Wir melden uns bei Ihnen so schnell wie möglich. Gern besprechen wir, ob und wie Sie als Entdecker der Schwachstelle
+benannt werden können.

--- a/mkver.conf
+++ b/mkver.conf
@@ -2,7 +2,6 @@ defaults {
   tag: false
   tagMessageFormat: "release {Tag}"
   preReleaseFormat: "RC{PreReleaseNumber}"
-  buildMetaDataFormat: "{Branch}.{ShortHash}"
   includeBuildMetaData: true
   whenNoValidCommitMessages: IncrementPatch
   patches: [
@@ -13,6 +12,15 @@ branches: [
   {
     pattern: "main"
     includeBuildMetaData: false
+    formats: [
+      { name: Docker, format: "{Version}" }
+    ]
+  }
+  {
+    pattern: ".*"
+    formats: [
+      { name: Docker, format: "{Version}_{BuildMetaData}" }
+    ]
   }
 ]
 patches: [


### PR DESCRIPTION
docs: add security policy
ci: add version as docker tags, use explicit version of node
ci: change from stages to needs and prevent release on scheduled