### PR TITLE
feat: move voting status translation

### DIFF
--- a/src/app/shared/components/poll-options/poll-options.component.html
+++ b/src/app/shared/components/poll-options/poll-options.component.html
@@ -10,8 +10,10 @@
           class="form-check-label"
           for="{{getPrefix()}}-voting-status-declined-{{selectorId}}"
         >
+          <span class="sr-only">{{ 'date.date' | translate }} {{ 'votingStatus.declined' | translate }}</span>
           <img
-            alt="{{ 'date.rejected' | translate }}"
+            alt="hidden"
+            aria-hidden="true"
             class="poll-option-icon"
             id="{{getPrefix()}}-label-status-declined-{{selectorId}}"
             src="assets/status_declined.svg"
@@ -37,9 +39,9 @@
           class="w-100 form-check-label"
           for="{{getPrefix()}}-voting-status-questionable-{{selectorId}}"
         >
-          <span class="sr-only">{{ 'date.questionable' | translate }}</span>
+          <span class="sr-only">{{ 'date.date' | translate }} {{ 'votingStatus.questionable' | translate }}</span>
           <img
-            alt="yellow question mark"
+            alt="hidden"
             aria-hidden="true"
             class="poll-option-icon"
             id="{{getPrefix()}}-label-status-questionable-{{selectorId}}"
@@ -66,9 +68,9 @@
           class="form-check-label"
           for="{{getPrefix()}}-voting-status-accepted-{{selectorId}}"
         >
-          <span class="sr-only">{{ 'date.accepted' | translate }}</span>
+          <span class="sr-only">{{ 'date.date' | translate }} {{ 'votingStatus.accepted' | translate }}</span>
           <img
-            alt="green check mark"
+            alt="hidden"
             aria-hidden="true"
             class="poll-option-icon"
             id="{{getPrefix()}}-label-status-accepted-{{selectorId}}"

--- a/src/locales/de-DE-du.json
+++ b/src/locales/de-DE-du.json
@@ -83,6 +83,7 @@
     "unknown": "unbekannt"
   },
   "date": {
+    "date": "Termin",
     "dateTo": "bis {{date}}",
     "choose": "Wähle deine Termine aus!",
     "change": "Ändere deine Termine!",
@@ -90,9 +91,6 @@
     "enter": "Termineingabe",
     "start": "Startdatum",
     "add": "Weiteres Datum hinzufügen",
-    "rejected": "Termin abgelehnt",
-    "questionable": "Termin fraglich",
-    "accepted": "Termin zugestimmt",
     "placeholder": "TT.MM.JJJJ",
     "setStart": "Bitte gib ein Startdatum an.",
     "startInvalid": "Bitte gib ein gültiges Startdatum an.",

--- a/src/locales/de-DE-sie.json
+++ b/src/locales/de-DE-sie.json
@@ -83,6 +83,7 @@
     "unknown": "unbekannt"
   },
   "date": {
+    "date": "Termin",
     "dateTo": "bis {{date}}",
     "choose": "Wählen Sie Ihre Termine aus!",
     "change": "Ändern Sie Ihre Termine!",
@@ -90,9 +91,6 @@
     "enter": "Termineingabe",
     "start": "Startdatum",
     "add": "Weiteres Datum hinzufügen",
-    "rejected": "Termin abgelehnt",
-    "questionable": "Termin fraglich",
-    "accepted": "Termin zugestimmt",
     "placeholder": "TT.MM.JJJJ",
     "setStart": "Bitte geben Sie ein Startdatum an.",
     "startInvalid": "Bitte geben Sie ein gültiges Startdatum an.",

--- a/src/locales/en-EN.json
+++ b/src/locales/en-EN.json
@@ -83,6 +83,7 @@
     "unknown": "unknown"
   },
   "date": {
+    "date": "Date",
     "dateTo": "to {{date}}",
     "choose": "Choose the dates!",
     "change": "Change dates!",
@@ -90,9 +91,6 @@
     "enter": "Enter date",
     "start": "Start date",
     "add": "Add another date",
-    "rejected": "Date rejected",
-    "questionable": "Date questionable",
-    "accepted": "Date accepted",
     "placeholder": "DD.MM.YYYY",
     "setStart": "Please set a start date.",
     "startInvalid": "Please set a valid start date.",

--- a/src/locales/platt.json
+++ b/src/locales/platt.json
@@ -75,6 +75,7 @@
     "unknown": "."
   },
   "date": {
+    "date": "Termin",
     "dateTo": "{{date}}",
     "choose": "Wähl dien Termin ut!",
     "change": "Ännern dien Termin!",


### PR DESCRIPTION
Related to https://github.com/Dataport/terminfinder-frontend/pull/196#discussion_r1591044558

Ziel ist es, die Status Übersetzungen zu vereinfachen.

Vorteile:
- ein einziger json Parameter zum Verändern der Übersetzung
- es kommt zu weniger Differenz (z.B. vorbehaltlich - fraglich)
Nachteile:
- im json gibt es Parameter mit camelCase.
- ausschließliche Verwendung in PollOptions Component.