### PR TITLE
fix: make validation messages more accessible

### DIFF
--- a/cypress/e2e/password-view.cy.ts
+++ b/cypress/e2e/password-view.cy.ts
@@ -28,12 +28,7 @@ context('password-view', () => {
       cy.get('#head');
       cy.get('[data-id=headerTitle]');
 
-      cy.get('[data-id=planningLogo]');
-      cy.get('[data-id=planningText]');
-      cy.get('[data-id=securityLogo]');
-      cy.get('[data-id=securityText]');
-      cy.get('[data-id=networkingLogo]');
-      cy.get('[data-id=networkingText]');
+      cy.get('[data-id=adIcons]');
       cy.get('[data-id=locked]');
       cy.get('[data-id=enter]');
       cy.get('[data-id=passwordInput]')

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -71,6 +71,7 @@ import {PrivacyComponent} from './juristic/privacy/privacy.component';
 import {TermsOfServiceComponent} from './juristic/terms-of-service/terms-of-service.component';
 import {CheckboxFieldComponent} from "./shared/components/checkbox-field/checkbox-field.component";
 import {PlainLanguageComponent} from "./signing-video/plain-language.component";
+import {AdIconsComponent} from "./shared/components/ad-icons/ad-icons.component";
 
 export const appRoutes: Routes = [
   {path: 'home', component: HomeComponent},
@@ -165,7 +166,8 @@ export function createTranslateLoader(http: HttpClient) {
     AutofocusDirective,
     BomComponent,
     PrivacyComponent,
-    TermsOfServiceComponent
+    TermsOfServiceComponent,
+    AdIconsComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/create-appointment/create-appointment.component.html
+++ b/src/app/create-appointment/create-appointment.component.html
@@ -36,6 +36,7 @@
                   data-id="msgRequiredTitle"
                   id="required-title"
                 >
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'poll.title.noTitle' | translate }}
                 </div>
               }
@@ -45,6 +46,7 @@
                   data-id="msgInvalidTitle"
                   id="invalid-title"
                 >
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'poll.title.invalid' | translate }}
                 </div>
               }
@@ -54,6 +56,7 @@
                   data-id="msgLongTitle"
                   id="maxLength-title"
                 >
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'poll.title.tooLong' | translate }}
                 </div>
               }
@@ -83,6 +86,7 @@
                   class="invalid-message"
                   data-id="msgRequiredName"
                 >
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'poll.details.name.noName' | translate }}
                 </div>
               }
@@ -92,6 +96,7 @@
                   data-id="msgInvalidName"
                   id="invalid-name"
                 >
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'poll.details.name.invalid' | translate }}
                 </div>
               }
@@ -100,6 +105,7 @@
                   class="invalid-message"
                   data-id="msgLongName"
                 >
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'poll.details.name.tooLong' | translate }}
                 </div>
               }
@@ -128,6 +134,7 @@
                   data-id="msgInvalidLocation"
                   id="invalid-location"
                 >
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'poll.details.place.invalid' | translate }}
                 </div>
               }
@@ -137,6 +144,7 @@
                   data-id="msgLongLocation"
                   id="maxLength-location"
                 >
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'poll.details.place.tooLong' | translate }}
                 </div>
               }
@@ -171,6 +179,7 @@
                   data-id="msgLongDescription"
                   id="maxLength-description"
                 >
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'poll.details.description.tooLong' | translate }}
                 </div>
               }

--- a/src/app/create-appointment/create-appointment.component.html
+++ b/src/app/create-appointment/create-appointment.component.html
@@ -26,7 +26,7 @@
             <div class="col-auto d-flex justify-content-end align-items-center icon-frame">
               <img alt="key" class="icon m-2 mt-3 mt-lg-4" src="assets/title.svg">
             </div>
-            <div class="col">
+            <div class="col invalid-message-highlight">
               <label data-id="titleLabel" for="title">{{ 'poll.title.placeholder' | translate }}</label>
               <input class="form-control" data-id="titleInput" formControlName="title" id="title"
                      placeholder="{{ 'poll.title.title' | translate }}" type="text">
@@ -69,7 +69,7 @@
             <div class="col-auto d-flex justify-content-end align-items-center icon-frame">
               <img alt="key" class="icon m-2 mt-3 mt-lg-4" src="assets/user.svg">
             </div>
-            <div class="col">
+            <div class="col invalid-message-highlight">
               <label data-id="nameLabel" for="name">{{ 'poll.details.name.yourName' | translate }}</label>
               <input
                 appAutoFocus
@@ -118,7 +118,7 @@
             <div class="col-auto d-flex justify-content-end align-items-center icon-frame">
               <img alt="Ort" class="icon m-2 mt-3 mt-lg-4" src="assets/location.svg">
             </div>
-            <div class="col">
+            <div class="col invalid-message-highlight">
               <label data-id="locationLabel" for="location">{{ 'poll.details.place.placeOptional' | translate }}</label>
               <input
                 class="form-control"
@@ -157,7 +157,7 @@
             <div class="col-auto d-flex justify-content-end align-items-center icon-frame">
               <img alt="Sprechblase" class="icon m-2 mt-3 mt-lg-4" src="assets/description.svg">
             </div>
-            <div class="col">
+            <div class="col invalid-message-highlight">
               <label
                 data-id="descriptionLabel"
                 for="description"

--- a/src/app/create-appointment/create-appointment.component.html
+++ b/src/app/create-appointment/create-appointment.component.html
@@ -29,7 +29,8 @@
             <div class="col invalid-message-highlight">
               <label data-id="titleLabel" for="title">{{ 'poll.title.placeholder' | translate }}</label>
               <input class="form-control" data-id="titleInput" formControlName="title" id="title"
-                     placeholder="{{ 'poll.title.title' | translate }}" type="text">
+                     placeholder="{{ 'poll.title.title' | translate }}" type="text"
+                     aria-describedby="required-title invalid-title maxLength-title">
               @if ((title.dirty || title.touched) && !!title.errors?.required) {
                 <div
                   class="invalid-message"
@@ -80,11 +81,13 @@
                 placeholder="{{ 'poll.details.name.name' | translate }}"
                 required
                 type="text"
+                aria-describedby="required-name invalid-name long-name"
               >
               @if ((name.dirty || name.touched) && !!name.errors?.required) {
                 <div
                   class="invalid-message"
                   data-id="msgRequiredName"
+                  id="required-name"
                 >
                   <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'poll.details.name.noName' | translate }}
@@ -104,6 +107,7 @@
                 <div
                   class="invalid-message"
                   data-id="msgLongName"
+                  id="long-name"
                 >
                   <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'poll.details.name.tooLong' | translate }}
@@ -127,6 +131,7 @@
                 id="location"
                 placeholder="{{ 'poll.details.place.place' | translate }}"
                 type="text"
+                aria-describedby="invalid-location maxLength-location"
               >
               @if (!!location.errors?.invalidName) {
                 <div
@@ -172,6 +177,7 @@
                 placeholder="{{ 'poll.details.description.description' | translate }}"
                 rows="4"
                 type="text"
+                aria-describedby="maxLength-description"
               ></textarea>
               @if (!!description.errors?.maxlength) {
                 <div

--- a/src/app/create-suggested-dates/create-suggested-dates.component.html
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.html
@@ -51,7 +51,7 @@
             <div class="row">
               <!-- start date -->
               <div [ngClass]="getShowSuggestedDateEndDateOnDifferentDayFormValue(i) ? 'col-6' : 'col'"
-                   class="col px-1 px-lg-3 my-1 form-group">
+                   class="col px-1 px-lg-3 my-1 form-group invalid-message-highlight">
                 <label data-id="startDateLabel"
                        for="suggested-date-start-date-{{i}}">{{ 'date.start' | translate }}</label>
                 @if (!isMobileDevice) {
@@ -138,7 +138,7 @@
                 <div
                   [ngClass]="{'has-error': getEndDateOfSuggestedStartDateByIndex(i).invalid
                   && (getEndDateOfSuggestedStartDateByIndex(i).dirty || getEndDateOfSuggestedStartDateByIndex(i).touched)}"
-                  class="col-6 col-lg px-1 px-lg-3 my-1 form-group">
+                  class="col-6 col-lg px-1 px-lg-3 my-1 form-group has-error-highlight">
                   <label for="suggested-date-end-date-{{i}}">{{ 'date.end' | translate }}</label>
                   @if (!isMobileDevice) {
                     <div class="input-group date">
@@ -200,7 +200,7 @@
             <!-- button to display start time and end time controls on the top row -->
             @if (!getShowStartDateStartTimeControlValue(i) && !getStartTimeOfSuggestedStartDateByIndex(i).value) {
               <div
-                class="col suggested-date-timepicker-start">
+                class="col suggested-date-timepicker-start has-error-highlight">
                 <div class="row">
                   <div class="col px-1 px-lg-3 my-1 form-group">
                     <label for="suggested-date-start-time-{{i}}">{{ 'time.time' | translate }}</label>
@@ -230,7 +230,7 @@
               <div
                 [ngClass]="{'has-error': getStartTimeOfSuggestedStartDateByIndex(i).invalid
                   && (getStartTimeOfSuggestedStartDateByIndex(i).dirty || getStartTimeOfSuggestedStartDateByIndex(i).touched)}"
-                class="col col-lg-3 px-1 px-lg-3 my-1 suggested-date-timepicker-start form-group">
+                class="col col-lg-3 px-1 px-lg-3 my-1 suggested-date-timepicker-start has-error-highlight form-group">
                 <label for="suggested-date-start-time-{{i}}">{{ 'time.start' | translate }}</label>
                 @if (!isMobileDevice) {
                   <div class="row g-0 input-group date justify-content-center align-items-start"
@@ -280,7 +280,7 @@
               <div
                 [ngClass]="{'has-error': getEndTimeOfSuggestedStartDateByIndex(i).invalid
                  && (getEndTimeOfSuggestedStartDateByIndex(i).dirty || getEndTimeOfSuggestedStartDateByIndex(i).touched)}"
-                class="col-6 col-lg-3 px-1 px-lg-3 my-1 suggested-date-timepicker-start form-group">
+                class="col-6 col-lg-3 px-1 px-lg-3 my-1 suggested-date-timepicker-start has-error-highlight form-group">
                 <label for="suggested-date-end-time-{{i}}">{{ 'time.end' | translate }}</label>
                 @if (!isMobileDevice) {
                   <div class="row g-0 input-group date justify-content-center align-items-start"
@@ -351,7 +351,7 @@
               <!-- button to display start time and end time controls on the bottom row -->
               @if (!getShowStartDateStartTimeControlValue(i) && !getStartTimeOfSuggestedStartDateByIndex(i).value) {
                 <div
-                  class="col-12 col-lg-6 px-1 px-lg-3 suggested-date-timepicker-start text-center">
+                  class="col-12 col-lg-6 px-1 px-lg-3 suggested-date-timepicker-start has-error-highlight text-center">
                   <div class="justify-content-start">
                     <label class="float-start" for="suggested-date-start-time-{{i}}">
                       {{ 'time.time' | translate }}
@@ -381,7 +381,7 @@
                 <div
                   [ngClass]="{'has-error': getStartTimeOfSuggestedStartDateByIndex(i).invalid
                     && (getStartTimeOfSuggestedStartDateByIndex(i).dirty || getStartTimeOfSuggestedStartDateByIndex(i).touched)}"
-                  class="col-6 col-lg px-1 px-lg-3 my-1 form-group suggested-date-timepicker-start">
+                  class="col-6 col-lg px-1 px-lg-3 my-1 form-group suggested-date-timepicker-start has-error-highlight">
                   <label for="suggested-date-start-time-{{i}}">{{ 'time.start' | translate }}</label>
                   @if (!isMobileDevice) {
                     <div class="row g-0 input-group date"
@@ -432,7 +432,7 @@
                 <div
                   [ngClass]="{'has-error': getEndTimeOfSuggestedEndDateByIndex(i).invalid
                    && (getEndTimeOfSuggestedEndDateByIndex(i).dirty || getEndTimeOfSuggestedEndDateByIndex(i).touched)}"
-                  class="col-6 col-lg px-1 px-lg-3 my-1 form-group suggested-date-timepicker-start">
+                  class="col-6 col-lg px-1 px-lg-3 my-1 form-group suggested-date-timepicker-start has-error-highlight">
                   <label for="suggested-date-end-time-different-day-{{i}}">{{ 'time.end' | translate }}</label>
                   @if (!isMobileDevice) {
                     <div class="row g-0 input-group date"

--- a/src/app/create-suggested-dates/create-suggested-dates.component.html
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.html
@@ -74,6 +74,7 @@
                       id="suggested-date-start-date-{{i}}"
                       ngbDatepicker
                       placeholder="{{ 'date.placeholder' | translate }}"
+                      aria-describedby="required-start-date invalid-start-date not-in-future-start-date"
                     >
                   </div>
                 } @else {
@@ -96,6 +97,7 @@
                       min="{{now.toDate() | date: 'yyyy-MM-dd'}}"
                       name="startDate"
                       type="date"
+                      aria-describedby="required-start-date invalid-start-date not-in-future-start-date"
                     >
                   </div>
                 }
@@ -105,6 +107,7 @@
                   <div
                     class="invalid-message no-padding"
                     data-id="msgRequiredStartDate"
+                    id="required-start-date"
                   >
                     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                     {{ 'date.setStart' | translate }}
@@ -116,6 +119,7 @@
                   <div
                     class="invalid-message no-padding"
                     data-id="msgInvalidStartDate"
+                    id="invalid-start-date"
                   >
                     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                     {{ 'date.startInvalid' | translate }}
@@ -127,6 +131,7 @@
                   <div
                     class="invalid-message no-padding"
                     data-id="msgNotInFutureStartDate"
+                    id="not-in-future-start-date"
                   >
                     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                     {{ 'date.startFuture' | translate }}
@@ -159,6 +164,7 @@
                         id="suggested-date-end-date-{{i}}"
                         ngbDatepicker
                         placeholder="{{ 'date.placeholder' | translate }}"
+                        aria-describedby="invalid-date start-date-after-end-date"
                       >
                     </div>
                   } @else {
@@ -178,15 +184,15 @@
                         class="form-control date" data-target-input="nearest" id="suggested-date-end-date-{{i}}"
                         min="{{getDateAsIsoString('startDate', i)}}"
                         name="endDate"
-                        type="date">
+                        type="date"
+                        aria-describedby="invalid-date start-date-after-end-date"
+                      >
                     </div>
                   }
                   @if ((getEndDateOfSuggestedStartDateByIndex(i).dirty
                     || getEndDateOfSuggestedStartDateByIndex(i).touched)
                   && !!getEndDateOfSuggestedStartDateByIndex(i).errors?.invalidDate) {
-                    <div
-                      class="invalid-message"
-                    >
+                    <div class="invalid-message" id="invalid-date">
                       <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                       {{ 'date.endInvalid' | translate }}
                     </div>
@@ -249,6 +255,7 @@
                           formControlName="startTime"
                           id="suggested-date-start-time-{{i}}"
                           placeholder="{{ 'time.placeholder' | translate }}"
+                          aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
                         >
                       </div>
                     </div>
@@ -270,7 +277,9 @@
                       class="form-control time"
                       id="suggested-date-start-time-{{i}}"
                       name="startTime"
-                      type="time">
+                      type="time"
+                      aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
+                    >
                   </div>
                 }
               </div>
@@ -299,6 +308,7 @@
                           formControlName="startDateEndTime"
                           id="suggested-date-end-time-{{i}}"
                           placeholder="{{ 'time.placeholder' | translate }}"
+                          aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
                         >
                       </div>
                     </div>
@@ -320,7 +330,9 @@
                       class="form-control time"
                       id="suggested-date-end-time-{{i}}"
                       name="startDateEndTime"
-                      type="time">
+                      type="time"
+                      aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
+                    >
                   </div>
                 }
               </div>
@@ -400,6 +412,7 @@
                             formControlName="startTime"
                             id="suggested-date-start-time-{{i}}"
                             placeholder="{{ 'time.placeholder' | translate }}"
+                            aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
                           >
                         </div>
                       </div>
@@ -421,7 +434,9 @@
                         class="form-control time"
                         id="suggested-date-start-time-{{i}}"
                         name="startTime"
-                        type="time">
+                        type="time"
+                        aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
+                      >
                     </div>
                   }
                 </div>
@@ -451,6 +466,7 @@
                             formControlName="endDateEndTime"
                             id="suggested-date-end-time-different-day-{{i}}"
                             placeholder="{{ 'time.placeholder' | translate }}"
+                            aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
                           >
                         </div>
                       </div>
@@ -471,7 +487,9 @@
                         class="form-control time"
                         id="suggested-date-end-time-different-day-{{i}}"
                         name="endDateEndTime"
-                        type="time">
+                        type="time"
+                        aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
+                      >
                     </div>
                   }
                 </div>
@@ -486,19 +504,19 @@
                   && (getSuggestedDatesForm(i).dirty || getSuggestedDatesForm(i).touched)}"
                  class="col my-1 px-1 px-lg-3 my-1 form-group">
               @if (!!getSuggestedDatesForm(i).errors?.startDateAfterEndDate) {
-                <div class="invalid-message">
+                <div class="invalid-message" id="start-date-after-end-date">
                   <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'date.startAfterEnd' | translate }}
                 </div>
               }
               @if (!!getSuggestedDatesForm(i).errors?.endTimeEnteredButNoStartTimeEntered) {
-                <div class="invalid-message">
+                <div class="invalid-message" id="end-time-entered-but-no-start-time-entered">
                   <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'date.noStart' | translate }}
                 </div>
               }
               @if (!!getSuggestedDatesForm(i).errors?.startDateTimeInPast) {
-                <div class="invalid-message">
+                <div class="invalid-message" id="start-date-time-in-past">
                   <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'date.inPast' | translate }}
                 </div>

--- a/src/app/create-suggested-dates/create-suggested-dates.component.html
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.html
@@ -357,144 +357,141 @@
         }
         <!-- bottom row for the time entry controls -->
         @if (getShowSuggestedDateEndDateOnDifferentDayFormValue(i)) {
-          <div
-            class="row g-0 justify-content-start align-items-start">
-            <div class="row">
-              <!-- button to display start time and end time controls on the bottom row -->
-              @if (!getShowStartDateStartTimeControlValue(i) && !getStartTimeOfSuggestedStartDateByIndex(i).value) {
-                <div
-                  class="col-12 col-lg-6 px-1 px-lg-3 suggested-date-timepicker-start has-error-highlight text-center">
-                  <div class="justify-content-start">
-                    <label class="float-start" for="suggested-date-start-time-{{i}}">
-                      {{ 'time.time' | translate }}
-                    </label>
-                    <div class="input-group date">
-                      <div class="input-group-prepend">
-                        <div class="input-group-text input-group-divider">
-                          <img alt="Add time" ngSrc="assets/add-time.svg" height="height" width="width">
-                        </div>
+          <div class="row g-0 justify-content-start align-items-start">
+            <!-- button to display start time and end time controls on the bottom row -->
+            @if (!getShowStartDateStartTimeControlValue(i) && !getStartTimeOfSuggestedStartDateByIndex(i).value) {
+              <div
+                class="col-12 col-lg-6 px-1 px-lg-3 suggested-date-timepicker-start has-error-highlight text-center">
+                <div class="justify-content-start">
+                  <label class="float-start" for="suggested-date-start-time-{{i}}">
+                    {{ 'time.time' | translate }}
+                  </label>
+                  <div class="input-group date">
+                    <div class="input-group-prepend">
+                      <div class="input-group-text input-group-divider">
+                        <img alt="Add time" ngSrc="assets/add-time.svg" height="height" width="width">
                       </div>
-                      <!--suppress XmlDuplicatedId these duplicate ids  will never appear on the page at the same time-->
-                      <button
-                        (click)="closeAllControlsExcept(i); setShowStartTimesControlValue(i, true);  setShowEndDateEndTimeControlValue(i, true)"
-                        [disabled]="isSuggestedDateFromDatabase(i)"
-                        class="form-control col date"
-                        data-id="addTimesWithEndOnOtherDay"
-                        type="button"
-                      >
-                        {{ 'time.add' | translate }}
-                      </button>
                     </div>
+                    <!--suppress XmlDuplicatedId these duplicate ids  will never appear on the page at the same time-->
+                    <button
+                      (click)="closeAllControlsExcept(i); setShowStartTimesControlValue(i, true);  setShowEndDateEndTimeControlValue(i, true)"
+                      [disabled]="isSuggestedDateFromDatabase(i)"
+                      class="form-control col date"
+                      data-id="addTimesWithEndOnOtherDay"
+                      type="button"
+                    >
+                      {{ 'time.add' | translate }}
+                    </button>
                   </div>
                 </div>
-              }
-              <!-- controls to enter start time - displayed if the button has been clicked or if values have been entered before -->
-              @if (getShowStartDateStartTimeControlValue(i) || getStartTimeOfSuggestedStartDateByIndex(i).value) {
-                <div
-                  [ngClass]="{'has-error': getStartTimeOfSuggestedStartDateByIndex(i).invalid
-                    && (getStartTimeOfSuggestedStartDateByIndex(i).dirty || getStartTimeOfSuggestedStartDateByIndex(i).touched)}"
-                  class="col-6 col-lg px-1 px-lg-3 my-1 form-group suggested-date-timepicker-start has-error-highlight">
-                  <label for="suggested-date-start-time-{{i}}">{{ 'time.start' | translate }}</label>
-                  @if (!isMobileDevice) {
-                    <div class="row g-0 input-group date"
-                         data-target-input="nearest">
-                      <div class="col-6">
-                        <div class="input-group date">
-                          <div class="input-group-prepend">
-                            <div class="input-group-text input-group-divider">
-                              <img alt="clock" ngSrc="assets/starttime.svg" height="height" width="width">
-                            </div>
+              </div>
+            }
+            <!-- controls to enter start time - displayed if the button has been clicked or if values have been entered before -->
+            @if (getShowStartDateStartTimeControlValue(i) || getStartTimeOfSuggestedStartDateByIndex(i).value) {
+              <div
+                [ngClass]="{'has-error': getStartTimeOfSuggestedStartDateByIndex(i).invalid
+                  && (getStartTimeOfSuggestedStartDateByIndex(i).dirty || getStartTimeOfSuggestedStartDateByIndex(i).touched)}"
+                class="col-6 col-lg px-1 px-lg-3 my-1 form-group suggested-date-timepicker-start has-error-highlight">
+                <label for="suggested-date-start-time-{{i}}">{{ 'time.start' | translate }}</label>
+                @if (!isMobileDevice) {
+                  <div class="row g-0 input-group date"
+                       data-target-input="nearest">
+                    <div class="col-6">
+                      <div class="input-group date">
+                        <div class="input-group-prepend">
+                          <div class="input-group-text input-group-divider">
+                            <img alt="clock" ngSrc="assets/starttime.svg" height="height" width="width">
                           </div>
-                          <!--suppress XmlDuplicatedId these duplicate ids  will never appear on the page at the same time-->
-                          <input
-                            class="form-control"
-                            data-id="startTimeInputSecondColumn"
-                            formControlName="startTime"
-                            id="suggested-date-start-time-{{i}}"
-                            placeholder="{{ 'time.placeholder' | translate }}"
-                            aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
-                          >
                         </div>
+                        <!--suppress XmlDuplicatedId these duplicate ids  will never appear on the page at the same time-->
+                        <input
+                          class="form-control"
+                          data-id="startTimeInputSecondColumn"
+                          formControlName="startTime"
+                          id="suggested-date-start-time-{{i}}"
+                          placeholder="{{ 'time.placeholder' | translate }}"
+                          aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
+                        >
                       </div>
                     </div>
-                  } @else {
-                    <div class="input-group" data-target-input="nearest">
-                      <div class="input-group-prepend">
-                        <div class="input-group-text input-group-divider">
-                          <img alt="clock" ngSrc="assets/starttime.svg" height="height" width="width">
-                        </div>
+                  </div>
+                } @else {
+                  <div class="input-group" data-target-input="nearest">
+                    <div class="input-group-prepend">
+                      <div class="input-group-text input-group-divider">
+                        <img alt="clock" ngSrc="assets/starttime.svg" height="height" width="width">
                       </div>
-                      <!--suppress XmlDuplicatedId these duplicate ids  will never appear on the page at the same time-->
-                      <input
-                        #mobileStartTimeInput
-                        (input)="parseAndSetTime('startTime', mobileStartTimeInput.value, i)"
-                        [disabled]="isSuggestedDateFromDatabase(i)"
-                        [value]="getTimeAsString('startTime', i)"
-                        appAutoFocus
-                        class="form-control time"
-                        id="suggested-date-start-time-{{i}}"
-                        name="startTime"
-                        type="time"
-                        aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
-                      >
                     </div>
-                  }
-                </div>
-              }
-              <!-- controls to enter the end time - displayed if the button has been clicked or if values have been entered before -->
-              @if (getShowStartDateStartTimeControlValue(i) && getShowEndDateEndTimeControlValue(i)
-              || getStartTimeOfSuggestedStartDateByIndex(i).value) {
-                <div
-                  [ngClass]="{'has-error': getEndTimeOfSuggestedEndDateByIndex(i).invalid
-                   && (getEndTimeOfSuggestedEndDateByIndex(i).dirty || getEndTimeOfSuggestedEndDateByIndex(i).touched)}"
-                  class="col-6 col-lg px-1 px-lg-3 my-1 form-group suggested-date-timepicker-start has-error-highlight">
-                  <label for="suggested-date-end-time-different-day-{{i}}">{{ 'time.end' | translate }}</label>
-                  @if (!isMobileDevice) {
-                    <div class="row g-0 input-group date"
-                         data-target-input="nearest">
-                      <div class="col-6">
-                        <div class="input-group date">
-                          <div class="input-group-prepend">
-                            <div class="input-group-text input-group-divider">
-                              <img alt="clock" ngSrc="assets/endtime.svg" height="height" width="width">
-                            </div>
+                    <!--suppress XmlDuplicatedId these duplicate ids  will never appear on the page at the same time-->
+                    <input
+                      #mobileStartTimeInput
+                      (input)="parseAndSetTime('startTime', mobileStartTimeInput.value, i)"
+                      [disabled]="isSuggestedDateFromDatabase(i)"
+                      [value]="getTimeAsString('startTime', i)"
+                      appAutoFocus
+                      class="form-control time"
+                      id="suggested-date-start-time-{{i}}"
+                      name="startTime"
+                      type="time"
+                      aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
+                    >
+                  </div>
+                }
+              </div>
+            }
+            <!-- controls to enter the end time - displayed if the button has been clicked or if values have been entered before -->
+            @if (getShowStartDateStartTimeControlValue(i) && getShowEndDateEndTimeControlValue(i)
+            || getStartTimeOfSuggestedStartDateByIndex(i).value) {
+              <div
+                [ngClass]="{'has-error': getEndTimeOfSuggestedEndDateByIndex(i).invalid
+                 && (getEndTimeOfSuggestedEndDateByIndex(i).dirty || getEndTimeOfSuggestedEndDateByIndex(i).touched)}"
+                class="col-6 col-lg px-1 px-lg-3 my-1 form-group suggested-date-timepicker-start has-error-highlight">
+                <label for="suggested-date-end-time-different-day-{{i}}">{{ 'time.end' | translate }}</label>
+                @if (!isMobileDevice) {
+                  <div class="row g-0 input-group date"
+                       data-target-input="nearest">
+                    <div class="col-6">
+                      <div class="input-group date">
+                        <div class="input-group-prepend">
+                          <div class="input-group-text input-group-divider">
+                            <img alt="clock" ngSrc="assets/endtime.svg" height="height" width="width">
                           </div>
-                          <!--suppress XmlDuplicatedId these duplicate ids  will never appear on the page at the same time-->
-                          <input
-                            class="form-control"
-                            data-id="endTimeInputSecondColumn"
-                            formControlName="endDateEndTime"
-                            id="suggested-date-end-time-different-day-{{i}}"
-                            placeholder="{{ 'time.placeholder' | translate }}"
-                            aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
-                          >
                         </div>
+                        <!--suppress XmlDuplicatedId these duplicate ids  will never appear on the page at the same time-->
+                        <input
+                          class="form-control"
+                          data-id="endTimeInputSecondColumn"
+                          formControlName="endDateEndTime"
+                          id="suggested-date-end-time-different-day-{{i}}"
+                          placeholder="{{ 'time.placeholder' | translate }}"
+                          aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
+                        >
                       </div>
                     </div>
-                  } @else {
-                    <div class="input-group" data-target-input="nearest">
-                      <div class="input-group-prepend">
-                        <div class="input-group-text input-group-divider"><img alt="clock" ngSrc="assets/endtime.svg" height="height" width="width">
-                        </div>
+                  </div>
+                } @else {
+                  <div class="input-group" data-target-input="nearest">
+                    <div class="input-group-prepend">
+                      <div class="input-group-text input-group-divider"><img alt="clock" ngSrc="assets/endtime.svg" height="height" width="width">
                       </div>
-                      <!--suppress XmlDuplicatedId these duplicate ids  will never appear on the page at the same time-->
-                      <input
-                        #mobileEndDateEndTimeInput
-                        (input)="parseAndSetTime('endDateEndTime', mobileEndDateEndTimeInput.value, i)"
-                        [disabled]="isSuggestedDateFromDatabase(i)"
-                        [value]="getTimeAsString('endDateEndTime', i)"
-                        appAutoFocus
-                        class="form-control time"
-                        id="suggested-date-end-time-different-day-{{i}}"
-                        name="endDateEndTime"
-                        type="time"
-                        aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
-                      >
                     </div>
-                  }
-                </div>
-              }
-            </div>
+                    <!--suppress XmlDuplicatedId these duplicate ids  will never appear on the page at the same time-->
+                    <input
+                      #mobileEndDateEndTimeInput
+                      (input)="parseAndSetTime('endDateEndTime', mobileEndDateEndTimeInput.value, i)"
+                      [disabled]="isSuggestedDateFromDatabase(i)"
+                      [value]="getTimeAsString('endDateEndTime', i)"
+                      appAutoFocus
+                      class="form-control time"
+                      id="suggested-date-end-time-different-day-{{i}}"
+                      name="endDateEndTime"
+                      type="time"
+                      aria-describedby="start-date-after-end-date end-time-entered-but-no-start-time-entered start-date-time-in-past"
+                    >
+                  </div>
+                }
+              </div>
+            }
           </div>
         }
         <!-- error messages for this date entry -->

--- a/src/app/create-suggested-dates/create-suggested-dates.component.html
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.html
@@ -541,7 +541,7 @@
           @if (!!getSuggestedDatesFromForm().errors?.invalidMaxLengthArray) {
             <div class="invalid-message">
               <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-              {{ 'date.tooMuchValues' | translate }}
+              {{ 'date.tooManyValues' | translate }}
             </div>
           }
         </div>

--- a/src/app/create-suggested-dates/create-suggested-dates.component.html
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.html
@@ -106,6 +106,7 @@
                     class="invalid-message no-padding"
                     data-id="msgRequiredStartDate"
                   >
+                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                     {{ 'date.setStart' | translate }}
                   </div>
                 }
@@ -116,6 +117,7 @@
                     class="invalid-message no-padding"
                     data-id="msgInvalidStartDate"
                   >
+                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                     {{ 'date.startInvalid' | translate }}
                   </div>
                 }
@@ -126,6 +128,7 @@
                     class="invalid-message no-padding"
                     data-id="msgNotInFutureStartDate"
                   >
+                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                     {{ 'date.startFuture' | translate }}
                   </div>
                 }
@@ -184,6 +187,7 @@
                     <div
                       class="invalid-message"
                     >
+                      <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                       {{ 'date.endInvalid' | translate }}
                     </div>
                   }
@@ -483,16 +487,19 @@
                  class="col my-1 px-1 px-lg-3 my-1 form-group">
               @if (!!getSuggestedDatesForm(i).errors?.startDateAfterEndDate) {
                 <div class="invalid-message">
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'date.startAfterEnd' | translate }}
                 </div>
               }
               @if (!!getSuggestedDatesForm(i).errors?.endTimeEnteredButNoStartTimeEntered) {
                 <div class="invalid-message">
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'date.noStart' | translate }}
                 </div>
               }
               @if (!!getSuggestedDatesForm(i).errors?.startDateTimeInPast) {
                 <div class="invalid-message">
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'date.inPast' | translate }}
                 </div>
               }
@@ -509,11 +516,13 @@
              class="col my-1 px-1 form-group">
           @if (!!getSuggestedDatesFromForm().errors?.invalidMinLengthArray) {
             <div class="invalid-message">
+              <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
               {{ 'date.noValue' | translate }}
             </div>
           }
           @if (!!getSuggestedDatesFromForm().errors?.invalidMaxLengthArray) {
             <div class="invalid-message">
+              <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
               {{ 'date.tooMuchValues' | translate }}
             </div>
           }

--- a/src/app/create-suggested-dates/create-suggested-dates.component.html
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.html
@@ -50,8 +50,15 @@
           <div class="col-12 col-lg">
             <div class="row">
               <!-- start date -->
-              <div [ngClass]="getShowSuggestedDateEndDateOnDifferentDayFormValue(i) ? 'col-6' : 'col'"
-                   class="col px-1 px-lg-3 my-1 form-group invalid-message-highlight">
+              <div
+                class="col px-1 px-lg-3 my-1 form-group invalid-message-highlight"
+                [ngClass]="{
+                  'has-error': getStartDateOfSuggestedStartDateByIndex(i).invalid
+                     && (getStartDateOfSuggestedStartDateByIndex(i).dirty || getStartDateOfSuggestedStartDateByIndex(i).touched),
+                  'col-6': getShowSuggestedDateEndDateOnDifferentDayFormValue(i),
+                  'col': !getShowSuggestedDateEndDateOnDifferentDayFormValue(i)
+                }"
+              >
                 <label data-id="startDateLabel"
                        for="suggested-date-start-date-{{i}}">{{ 'date.start' | translate }}</label>
                 @if (!isMobileDevice) {

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -52,6 +52,7 @@
                 class="invalid-message"
                 data-id="msgRequiredTitle"
               >
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ 'poll.title.noTitle' | translate }}
               </div>
             }
@@ -61,6 +62,7 @@
                 data-id="msgInvalidTitle"
                 id="invalid-title"
               >
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ 'poll.title.invalid' | translate }}
               </div>
             }
@@ -69,6 +71,7 @@
                 class="invalid-message"
                 data-id="msgLongTitle"
               >
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ 'poll.title.tooLong' | translate }}
               </div>
             }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -45,12 +45,14 @@
               formControlName="title"
               id="title"
               placeholder="{{ 'poll.title.placeholder' | translate }}"
+              aria-describedby="required-title invalid-title long-title"
               required
               type="text">
             @if ((title.dirty || title.touched) && !!title.errors?.required) {
               <div
                 class="invalid-message"
                 data-id="msgRequiredTitle"
+                id="required-title"
               >
                 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ 'poll.title.noTitle' | translate }}
@@ -70,6 +72,7 @@
               <div
                 class="invalid-message"
                 data-id="msgLongTitle"
+                id="long-title"
               >
                 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ 'poll.title.tooLong' | translate }}

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -10,20 +10,7 @@
         {{ notification.message }}
       </div>
     }
-    <div class="row g-0 justify-content-between" data-id="adIcons">
-      <div class="col">
-        <img alt="Planung" src="assets/search.svg">
-        <h3 class="text-center d-none d-lg-block text-bold circle-text">{{ 'home.planning' | translate }}</h3>
-      </div>
-      <div class="col">
-        <img alt="Sicherheit" src="assets/lock.svg">
-        <h3 class="text-center d-none d-lg-block text-bold circle-text">{{ 'home.security' | translate }}</h3>
-      </div>
-      <div class="col">
-        <img alt="Vernetzung" src="assets/calendar_network.svg">
-        <h3 class="text-center d-none d-lg-block text-bold circle-text">{{ 'home.networking' | translate }}</h3>
-      </div>
-    </div>
+    <app-ad-icons></app-ad-icons>
     <div class="row justify-content-center my-2 my-lg-4" data-id="createPollSlogan">
       <h2 class="text-center">
         {{ 'home.slogan' | translate }}

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -38,7 +38,7 @@
           <label class="col" data-id="createPollLabel" for="title">{{ 'poll.title.set' | translate }}</label>
         </div>
         <div class="form-row mb-2">
-          <div class="col">
+          <div class="col invalid-message-highlight">
             <input
               class="form-control"
               data-id="createPollInput"

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -1,10 +1,6 @@
 @import "src/default";
 @import 'bootstrap/scss/mixins';
 
-.circle-text {
-  margin-top: -1 * $spacer;
-}
-
 /* custom styles */
 label[for="title"] {
   margin-bottom: 0.25 * $spacer;

--- a/src/app/password/password.component.html
+++ b/src/app/password/password.component.html
@@ -56,6 +56,7 @@
             class="invalid-message"
             data-id="msgInvalid"
           >
+            <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
             {{ 'password.invalid' | translate }}
           </div>
         }

--- a/src/app/password/password.component.html
+++ b/src/app/password/password.component.html
@@ -27,7 +27,7 @@
       </div>
     </div>
     <div class="d-flex form-row justify-content-center mt-3">
-      <div class="col col-lg-8">
+      <div class="col col-lg-8 invalid-message-highlight">
         <input
           aria-hidden="true"
           autocomplete="off"

--- a/src/app/password/password.component.html
+++ b/src/app/password/password.component.html
@@ -1,103 +1,91 @@
-<div class="row justify-content-center">
-  <div class="col col-lg-10">
-    <div class="row g-0 justify-content-between">
-      <div class="col">
-        <img alt="Plane" data-id="planningLogo" src="assets/search.svg">
-        <h3 class="text-center d-none d-lg-block" data-id="planningText">{{ 'home.planning' | translate }}</h3>
-      </div>
-      <div class="col">
-        <img alt="Sicher" data-id="securityLogo" src="assets/lock.svg">
-        <h3 class="text-center d-none d-lg-block" data-id="securityText">{{ 'home.security' | translate }}</h3>
-      </div>
-      <div class="col">
-        <img alt="Vernetzt" data-id="networkingLogo" src="assets/calendar_network.svg">
-        <h3 class="text-center d-none d-lg-block" data-id="networkingText">{{ 'home.networking' | translate }}</h3>
-      </div>
+<div class="row g-0 justify-content-center">
+  <div class="col-11 col-lg-8">
+    <app-ad-icons></app-ad-icons>
+    <div class="row justify-content-center my-2 my-lg-4">
+      <h2 class="text-center" data-id="locked">
+        {{ 'password.locked' | translate }}
+      </h2>
+    </div>
+    <div class="row g-0 justify-content-center">
+      <form (ngSubmit)="onSubmit()" [formGroup]="passwordForm" class="col">
+        <div class="form-row justify-content-center">
+          <label class="col h3" data-id="enter" for="password">
+            {{ 'password.enter' | translate }}
+          </label>
+        </div>
+        <div class="form-row">
+          <div class="col invalid-message-highlight">
+            <input
+              aria-hidden="true"
+              autocomplete="off"
+              class="d-none"
+              id="hidden-username"
+              spellcheck="false"
+              tabindex="-1"
+              title="user"
+              type="text"
+              value=""
+            >
+            <input
+              (ngModelChange)="this.showIsInvalid = false;"
+              appAutoFocus
+              autocomplete="current-password"
+              class="form-control"
+              data-id="passwordInput"
+              formControlName="password"
+              id="password"
+              placeholder="{{ 'password.placeholder' | translate }}"
+              required
+              type="password"
+              aria-describedby="invalid"
+            >
+            @if (showIsInvalid && isInvalid) {
+              <div
+                class="invalid-message"
+                data-id="msgInvalid"
+                id="invalid"
+              >
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                {{ 'password.invalid' | translate }}
+              </div>
+            }
+          </div>
+        </div>
+        <div class="form-row justify-content-center mt-3">
+          <div class="col pt-3">
+            @if (!isAdmin) {
+              <button
+                [disabled]="passwordForm.invalid"
+                class="btn btn-secondary btn-submit w-100"
+                data-id="userButton"
+                type="submit"
+              >
+                <span class="icon-create-poll"></span>
+                {{ 'poll.participate' | translate }}
+                <img alt="{{ 'poll.participate' | translate }}"
+                     class="icon-create-poll"
+                     src="assets/icn_umfrage_erstellen.svg"
+                >
+              </button>
+            }
+            @if (isAdmin) {
+              <button
+                [disabled]="passwordForm.invalid"
+                class="btn btn-secondary btn-submit w-100"
+                data-id="adminButton"
+                type="submit"
+              >
+                <span class="icon-create-poll"></span>
+                {{ 'poll.edit' | translate }}
+                <img alt="{{ 'poll.edit' | translate }}"
+                     class="icon-create-poll"
+                     src="assets/icn_umfrage_erstellen.svg"
+                >
+              </button>
+            }
+          </div>
+        </div>
+      </form>
     </div>
   </div>
-</div>
-<div class="row mt-3 mt-lg-5">
-  <form (ngSubmit)="onSubmit()" [formGroup]="passwordForm" class="col">
-    <div class="form-row justify-content-center">
-      <div class="col">
-        <h2 class="text-center" data-id="locked">{{ 'password.locked' | translate }}</h2>
-        <label class="primary text-center w-100 h3" data-id="enter" for="password">
-          {{ 'password.enter' | translate }}
-        </label>
-      </div>
-    </div>
-    <div class="d-flex form-row justify-content-center mt-3">
-      <div class="col col-lg-8 invalid-message-highlight">
-        <input
-          aria-hidden="true"
-          autocomplete="off"
-          class="d-none"
-          id="hidden-username"
-          spellcheck="false"
-          tabindex="-1"
-          title="user"
-          type="text"
-          value=""
-        >
-        <input
-          (ngModelChange)="this.showIsInvalid = false;"
-          appAutoFocus
-          autocomplete="current-password"
-          class="form-control"
-          data-id="passwordInput"
-          formControlName="password"
-          id="password"
-          placeholder="{{ 'password.placeholder' | translate }}"
-          required
-          type="password"
-          aria-describedby="invalid"
-        >
-        @if (showIsInvalid && isInvalid) {
-          <div
-            class="invalid-message"
-            data-id="msgInvalid"
-            id="invalid"
-          >
-            <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-            {{ 'password.invalid' | translate }}
-          </div>
-        }
-      </div>
-    </div>
-    <div class="d-flex form-row justify-content-center mt-3">
-      <div class="col col-lg-8 pt-3">
-        @if (!isAdmin) {
-          <button
-            [disabled]="passwordForm.invalid"
-            class="btn btn-secondary btn-submit w-100"
-            data-id="userButton"
-            type="submit"
-          >
-            <span class="icon-create-poll"></span>
-            {{ 'poll.participate' | translate }}
-            <img alt="{{ 'poll.participate' | translate }}"
-                 class="icon-create-poll"
-                 src="assets/icn_umfrage_erstellen.svg"
-            >
-          </button>
-        }
-        @if (isAdmin) {
-          <button
-            [disabled]="passwordForm.invalid"
-            class="btn btn-secondary btn-submit w-100"
-            data-id="adminButton"
-            type="submit"
-          >
-            <span class="icon-create-poll"></span>
-            {{ 'poll.edit' | translate }}
-            <img alt="{{ 'poll.edit' | translate }}"
-                 class="icon-create-poll"
-                 src="assets/icn_umfrage_erstellen.svg"
-            >
-          </button>
-        }
-      </div>
-    </div>
-  </form>
-    <app-ad-icons></app-ad-icons>
 </div>

--- a/src/app/password/password.component.html
+++ b/src/app/password/password.component.html
@@ -50,11 +50,13 @@
           placeholder="{{ 'password.placeholder' | translate }}"
           required
           type="password"
+          aria-describedby="invalid"
         >
         @if (showIsInvalid && isInvalid) {
           <div
             class="invalid-message"
             data-id="msgInvalid"
+            id="invalid"
           >
             <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
             {{ 'password.invalid' | translate }}

--- a/src/app/password/password.component.html
+++ b/src/app/password/password.component.html
@@ -99,4 +99,5 @@
       </div>
     </div>
   </form>
+    <app-ad-icons></app-ad-icons>
 </div>

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -55,6 +55,7 @@
             && !!formHelper.getParticipantFormName().errors?.required) {
               <div
                 class="invalid-message">
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ 'poll.details.name.noName' | translate }}
               </div>
             }
@@ -62,11 +63,13 @@
               <div class="invalid-message"
                    id="invalid-add-name"
               >
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ 'poll.details.name.invalid' | translate }}
               </div>
             }
             @if (!!formHelper.getParticipantFormName().errors?.maxlength) {
               <div class="invalid-message">
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ 'poll.details.name.tooLong' | translate }}
               </div>
             }

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   @if (formHelper.pollForm && formHelper.appointment) {
     <div [formGroup]="formHelper.pollForm"
-         class="row g-0 toolbar d-lg-none p-1">
+         class="row g-0 toolbar d-lg-none p-1 invalid-message-highlight">
       <!-- add button ^ dropdown & edit button (only visible when _not_ in add or edit mode) -->
       @if (!formHelper.hasAddOrEditParticipantForm()) {
         <div class="col-auto mx-1">

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -171,6 +171,7 @@
                               class="invalid-message ml-2"
                               data-id="noNameMsg"
                             >
+                              <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                               {{ 'poll.details.name.noName' | translate }}
                             </div>
                           }
@@ -180,6 +181,7 @@
                               data-id="nameInvalidMsg"
                               id="invalid-add-name"
                             >
+                              <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                               {{ 'poll.details.name.invalid' | translate }}
                             </div>
                           }
@@ -188,6 +190,7 @@
                               class="invalid-message"
                               data-id="tooLongMsg"
                             >
+                              <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                               {{ 'poll.details.name.tooLong' | translate }}
                             </div>
                           }
@@ -294,6 +297,7 @@
                             && !!formHelper.getParticipantFormName().errors?.required) {
                               <div
                                 class="invalid-message">
+                                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                                 {{ 'poll.details.name.noName' | translate }}
                               </div>
                             }
@@ -302,6 +306,7 @@
                                 class="invalid-message"
                                 id="invalid-edit-name"
                               >
+                                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                                 {{ 'poll.details.name.invalid' | translate }}
                               </div>
                             }
@@ -309,6 +314,7 @@
                               <div
                                 class="invalid-message"
                               >
+                                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                                 {{ 'poll.details.name.tooLong' | translate }}
                               </div>
                             }

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -133,7 +133,7 @@
                       [formGroup]="formHelper.getParticipantForm()"
                       class="poll-add-user-row">
                     <td class="p-2 poll-data-cell name">
-                      <div class="row g-0">
+                      <div class="row g-0 invalid-message-highlight">
                         <!-- name -->
                         <div
                           [ngClass]="{'has-error': formHelper.getParticipantFormName().invalid
@@ -255,7 +255,7 @@
                     @if (formHelper.isEditInParticipantForm(participant.participantId)) {
                       <td (keydown.enter)="$event.preventDefault()"
                           [formGroup]="formHelper.getParticipantForm()" class="p-2 poll-data-cell name">
-                        <div class="row g-0">
+                        <div class="row g-0 invalid-message-highlight">
                           <!-- name input -->
                           <div
                             [ngClass]="{'has-error': formHelper.getParticipantFormName().invalid  &&

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -148,6 +148,7 @@
                             id="name-add"
                             placeholder="{{ 'participant.name' | translate }}"
                             type="text"
+                            aria-describedby="no-name-add invalid-add-name too-long-add"
                           >
                         </div>
                         <!-- button to remove the form elements (so the participant won't be added) -->
@@ -170,6 +171,7 @@
                             <div
                               class="invalid-message ml-2"
                               data-id="noNameMsg"
+                              id="no-name-add"
                             >
                               <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                               {{ 'poll.details.name.noName' | translate }}
@@ -189,6 +191,7 @@
                             <div
                               class="invalid-message"
                               data-id="tooLongMsg"
+                              id="too-long-add"
                             >
                               <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                               {{ 'poll.details.name.tooLong' | translate }}
@@ -275,6 +278,7 @@
                               id="name-edit"
                               placeholder="{{ 'participant.name' | translate }}"
                               type="text"
+                              aria-describedby="no-name-edit invalid-edit-name too-long-edit"
                             >
                           </div>
                           <!-- button to delete the currently edited participant -->
@@ -296,7 +300,7 @@
                             && (formHelper.getParticipantFormName().dirty || formHelper.getParticipantFormName().touched)
                             && !!formHelper.getParticipantFormName().errors?.required) {
                               <div
-                                class="invalid-message">
+                                class="invalid-message" id="no-name-edit">
                                 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                                 {{ 'poll.details.name.noName' | translate }}
                               </div>
@@ -311,9 +315,7 @@
                               </div>
                             }
                             @if (formHelper.getParticipantFormName() && !!formHelper.getParticipantFormName().errors?.maxlength) {
-                              <div
-                                class="invalid-message"
-                              >
+                              <div class="invalid-message" id="too-long-edit">
                                 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                                 {{ 'poll.details.name.tooLong' | translate }}
                               </div>

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -55,6 +55,7 @@
                 class="offset-1 col invalid-message"
                 data-id="errorMsgSetPassword"
               >
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ 'password.set' | translate }}
               </div>
             }
@@ -63,6 +64,7 @@
                 class="offset-1 col invalid-message"
                 data-id="errorMsgSetMinimum"
               >
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ 'password.setMinimum' | translate }}
               </div>
             }
@@ -100,6 +102,7 @@
                   class="col invalid-message"
                   data-id="errorMsgNoMatch"
                 >
+                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'password.noMatch' | translate }}
                 </div>
               }

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -37,7 +37,7 @@
               </label>
             </div>
           </div>
-          <div class="row g-0">
+          <div class="row g-0 invalid-message-highlight">
             <div class="col-1 d-flex justify-content-end align-items-center">
               <img alt="key" class="icon m-2" src="assets/password.svg">
             </div>
@@ -79,7 +79,7 @@
               </label>
             </div>
           </div>
-          <div class="row g-0">
+          <div class="row g-0 invalid-message-highlight">
             <div class="col-1 d-flex justify-content-end align-items-center">
               <img alt="key" class="icon m-2" src="assets/password.svg">
             </div>

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -86,32 +86,31 @@
             <div class="col-1 d-flex justify-content-end align-items-center">
               <img alt="key" class="icon m-2" src="assets/password.svg">
             </div>
-            <div class="col-11 px-0">
-              <input
-                [placeholder]="showPlaceholder ? '********' : ''"
-                autocomplete="new-password"
-                class="slim-input w-100 px-0"
-                data-id="repeatPasswordInput" formControlName="passwordRepeat"
-                id="password-repeat"
-                type="password"
-                aria-describedby="no-match"
+            <input
+              [placeholder]="showPlaceholder ? '********' : ''"
+              autocomplete="new-password"
+              class="px-0 slim-input col-11"
+              data-id="repeatPasswordInput"
+              formControlName="passwordRepeat"
+              id="password-repeat"
+              type="password"
+              aria-describedby="no-match"
+            >
+            <!-- show message if:
+                  - passwordRepeat is 'dirty' and not same
+                  - passwordRepeat has been auto-filled and password has been changed -->
+            @if ((getPasswordRepeat().touched && getPasswordRepeat().dirty
+                     || getPassword().dirty && !!getPasswordRepeat().value)
+                     && !!settingsForm.errors?.notSame) {
+              <div
+                class="offset-1 col invalid-message"
+                data-id="errorMsgNoMatch"
+                id="no-match"
               >
-              <!-- show message if:
-                    - passwordRepeat is 'dirty' and not same
-                    - passwordRepeat has been auto-filled and password has been changed -->
-              @if ((getPasswordRepeat().touched && getPasswordRepeat().dirty
-                       || getPassword().dirty && !!getPasswordRepeat().value)
-                       && !!settingsForm.errors?.notSame) {
-                <div
-                  class="col invalid-message"
-                  data-id="errorMsgNoMatch"
-                  id="no-match"
-                >
-                  <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                  {{ 'password.noMatch' | translate }}
-                </div>
-              }
-            </div>
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                {{ 'password.noMatch' | translate }}
+              </div>
+            }
           </div>
         }
       </div>

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -49,11 +49,13 @@
               formControlName="password"
               id="password"
               type="password"
+              aria-describedby="set-password set-minimum"
             />
             @if ((getPassword().touched || getPassword().dirty) && !!getPassword().errors?.required) {
               <div
                 class="offset-1 col invalid-message"
                 data-id="errorMsgSetPassword"
+                id="set-password"
               >
                 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ 'password.set' | translate }}
@@ -63,6 +65,7 @@
               <div
                 class="offset-1 col invalid-message"
                 data-id="errorMsgSetMinimum"
+                id="set-minimum"
               >
                 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                 {{ 'password.setMinimum' | translate }}
@@ -91,6 +94,7 @@
                 data-id="repeatPasswordInput" formControlName="passwordRepeat"
                 id="password-repeat"
                 type="password"
+                aria-describedby="no-match"
               >
               <!-- show message if:
                     - passwordRepeat is 'dirty' and not same
@@ -101,6 +105,7 @@
                 <div
                   class="col invalid-message"
                   data-id="errorMsgNoMatch"
+                  id="no-match"
                 >
                   <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                   {{ 'password.noMatch' | translate }}

--- a/src/app/settings/settings.component.scss
+++ b/src/app/settings/settings.component.scss
@@ -14,3 +14,20 @@ img.icon {
   width: 30px;
   height: 30px;
 }
+
+.invalid-message-highlight:has(.invalid-message) {
+  &::before {
+    @media (min-width: map-get($grid-breakpoints, xs)) {
+      left: -1.35rem !important;
+    }
+    @media (min-width: map-get($grid-breakpoints, sm)) {
+      left: -.75rem !important;
+    }
+    @media (min-width: map-get($grid-breakpoints, md)) {
+      left: .25rem !important;
+    }
+    @media (min-width: map-get($grid-breakpoints, lg)) {
+      left: .5rem !important;
+    }
+  }
+}

--- a/src/app/shared/components/ad-icons/ad-icons.component.html
+++ b/src/app/shared/components/ad-icons/ad-icons.component.html
@@ -1,0 +1,14 @@
+<div class="row g-0 justify-content-between" data-id="adIcons">
+  <div class="col">
+    <img alt="Planung" src="assets/search.svg">
+    <h3 class="text-center d-none d-lg-block text-bold circle-text">{{ 'home.planning' | translate }}</h3>
+  </div>
+  <div class="col">
+    <img alt="Sicherheit" src="assets/lock.svg">
+    <h3 class="text-center d-none d-lg-block text-bold circle-text">{{ 'home.security' | translate }}</h3>
+  </div>
+  <div class="col">
+    <img alt="Vernetzung" src="assets/calendar_network.svg">
+    <h3 class="text-center d-none d-lg-block text-bold circle-text">{{ 'home.networking' | translate }}</h3>
+  </div>
+</div>

--- a/src/app/shared/components/ad-icons/ad-icons.component.scss
+++ b/src/app/shared/components/ad-icons/ad-icons.component.scss
@@ -1,0 +1,5 @@
+@import "src/default";
+
+.circle-text {
+  margin-top: -1 * $spacer;
+}

--- a/src/app/shared/components/ad-icons/ad-icons.component.ts
+++ b/src/app/shared/components/ad-icons/ad-icons.component.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'app-ad-icons',
+  templateUrl: './ad-icons.component.html',
+  styleUrl: './ad-icons.component.scss'
+})
+export class AdIconsComponent {
+  constructor() {
+  }
+}

--- a/src/app/shared/components/checkbox-field/checkbox-field.component.ts
+++ b/src/app/shared/components/checkbox-field/checkbox-field.component.ts
@@ -16,7 +16,7 @@ import {NgTemplateOutlet} from "@angular/common";
   template: `
     <div [class]="reverse ? 'form-check-reverse' : 'form-check'">
       <input [formControl]="ngControl.control" id="checkbox" data-id="checkbox" class="form-check-input" type="checkbox"
-             value="">
+             value="" [attr.aria-describedby]="ariaDescribedBy">
       <label for="checkbox" class="form-check-label w-100" [class.text-start]="reverse">
         @if (labelTemplate) {
           <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
@@ -37,4 +37,6 @@ export class CheckboxFieldComponent {
   labelTemplate: TemplateRef<any> | undefined;
   @Input()
   reverse = false;
+  @Input()
+  ariaDescribedBy = '';
 }

--- a/src/app/shared/components/tos/tos.component.html
+++ b/src/app/shared/components/tos/tos.component.html
@@ -14,4 +14,5 @@
       {{ 'tos.accept' | translate }}
     </div>
   }
+        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
 </div>

--- a/src/app/shared/components/tos/tos.component.html
+++ b/src/app/shared/components/tos/tos.component.html
@@ -1,6 +1,6 @@
 <div class="form-row invalid-message-highlight">
   <div class="col section-container py-2 px-3">
-    <app-checkbox-field [formControl]="isTosRead" [labelTemplate]="tosLabelTemplate"/>
+    <app-checkbox-field [formControl]="isTosRead" [labelTemplate]="tosLabelTemplate" ariaDescribedBy="tos-accept"/>
 
     <ng-template #tosLabelTemplate>
       {{ 'tos.accept_0' | translate }}
@@ -11,7 +11,7 @@
     </ng-template>
 
     @if (isTosRead.dirty && isTosRead.invalid) {
-      <div class="col-12 invalid-message">
+      <div class="col-12 invalid-message" id="tos-accept">
         <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
         {{ 'tos.accept' | translate }}
       </div>

--- a/src/app/shared/components/tos/tos.component.html
+++ b/src/app/shared/components/tos/tos.component.html
@@ -1,18 +1,20 @@
-<div class="col section-container py-2 px-3">
-  <app-checkbox-field [formControl]="isTosRead" [labelTemplate]="tosLabelTemplate"/>
+<div class="form-row invalid-message-highlight">
+  <div class="col section-container py-2 px-3">
+    <app-checkbox-field [formControl]="isTosRead" [labelTemplate]="tosLabelTemplate"/>
 
-  <ng-template #tosLabelTemplate>
-    {{ 'tos.accept_0' | translate }}
-    <a data-cy="tosLink" routerLink="/termsOfService">{{ 'tos.tos' | translate }}</a>
-    {{ 'tos.accept_1' | translate }}
-    <a data-cy="tosPrivacyLink" routerLink="/privacy">{{ 'privacy.declaration' | translate }}</a>
-    {{ 'tos.accept_2' | translate }}
-  </ng-template>
+    <ng-template #tosLabelTemplate>
+      {{ 'tos.accept_0' | translate }}
+      <a data-cy="tosLink" routerLink="/termsOfService">{{ 'tos.tos' | translate }}</a>
+      {{ 'tos.accept_1' | translate }}
+      <a data-cy="tosPrivacyLink" routerLink="/privacy">{{ 'privacy.declaration' | translate }}</a>
+      {{ 'tos.accept_2' | translate }}
+    </ng-template>
 
-  @if (isTosRead.dirty && isTosRead.invalid) {
-    <div class="col-12 invalid-message">
-      {{ 'tos.accept' | translate }}
-    </div>
-  }
+    @if (isTosRead.dirty && isTosRead.invalid) {
+      <div class="col-12 invalid-message">
         <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+        {{ 'tos.accept' | translate }}
+      </div>
+    }
+  </div>
 </div>

--- a/src/locales/de-DE-du.json
+++ b/src/locales/de-DE-du.json
@@ -111,7 +111,7 @@
     "noStart": "Bitte gib eine gültige Startzeit an. Wenn eine Endezeit angegeben wird, muss eine Startzeit angegeben werden.",
     "inPast": "Bitte gib ein gültiges Startdatum bzw. Startzeitpunkt an. Der Startzeitpunkt muss in der Zukunft liegen.",
     "noValue": "Es muss mindestens eine Terminoption angegeben werden.",
-    "tooMuchValues": "Es dürfen nicht mehr als 100 Terminoptionen angegeben werden."
+    "tooManyValues": "Es dürfen nicht mehr als 100 Terminoptionen angegeben werden."
   },
   "time": {
     "time": "Uhrzeit",

--- a/src/locales/de-DE-sie.json
+++ b/src/locales/de-DE-sie.json
@@ -111,7 +111,7 @@
     "noStart": "Bitte geben Sie eine gültige Startzeit an. Wenn eine Endezeit angegeben wird, muss eine Startzeit angegeben werden.",
     "inPast": "Bitte geben Sie ein gültiges Startdatum bzw. Startzeitpunkt an. Der Startzeitpunkt muss in der Zukunft liegen.",
     "noValue": "Es muss mindestens eine Terminoption angegeben werden.",
-    "tooMuchValues": "Es dürfen nicht mehr als 100 Terminoptionen angegeben werden."
+    "tooManyValues": "Es dürfen nicht mehr als 100 Terminoptionen angegeben werden."
   },
   "time": {
     "time": "Uhrzeit",

--- a/src/locales/en-EN.json
+++ b/src/locales/en-EN.json
@@ -111,7 +111,7 @@
     "noStart": "Please set a start date. If there is an end date, there has to be a start date.",
     "inPast": "Please enter a valid start date. The start date must be in the future.",
     "noValue": "There must be at least one date.",
-    "tooMuchValues": "More than 100 dates are not possible."
+    "tooManyValues": "More than 100 dates are not possible."
   },
   "time": {
     "time": "Time",

--- a/src/locales/platt.json
+++ b/src/locales/platt.json
@@ -105,7 +105,7 @@
     "noStart": "Bitte giff en gültig Starttiet an. Wenn en Enn angeven warrt, mutt en Starttiet angeven warrn.",
     "inPast": "Bitte giff en gültig Startdatum bzw. Startstiet an. De Startstiet muss in de Tokunft liggen.",
     "noValue": "Dat mutt mindst en Termin angeven warrn.",
-    "tooMuchValues": "Dat drööft nich mehr as 100 Terminschonen angeven warrn."
+    "tooManyValues": "Dat drööft nich mehr as 100 Terminschonen angeven warrn."
   },
   "time": {
     "time": "Uhrtied",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -70,8 +70,22 @@ label {
 .invalid-message-highlight:has(.invalid-message),
 .has-error-highlight:has(.has-error),
 .has-error-highlight.has-error {
-  border-left: .25rem solid $secondary;
-  padding-left: .25rem;
+  position: relative;
+
+  &::before {
+    content: '';
+    height: 100%;
+    width: .25rem;
+    border-left: .25rem solid $secondary;
+    position: absolute;
+    top: 0;
+    z-index: 1;
+    left: .25rem;
+  }
+
+  &:not(.form-group)::before {
+    left: -.5rem;
+  }
 }
 
 .checkbox-label:after {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -67,6 +67,13 @@ label {
   font-weight: bold;
 }
 
+.invalid-message-highlight:has(.invalid-message),
+.has-error-highlight:has(.has-error),
+.has-error-highlight.has-error {
+  border-left: .25rem solid $secondary;
+  padding-left: .25rem;
+}
+
 .checkbox-label:after {
   content: '';
   display: table;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -83,8 +83,14 @@ label {
     left: .25rem;
   }
 
-  &:not(.form-group)::before {
+  &.invalid-message-highlight:not(.form-group)::before {
     left: -.5rem;
+  }
+
+  @media (max-width: map-get($grid-breakpoints, lg)) {
+    &::before {
+      left: -.15rem;
+    }
   }
 }
 


### PR DESCRIPTION
## added

- use `aria-describedby` to connect messages with inputs for screenreaders

### highlight which element contains errors without relying on colors
- alert-icon before each message
- floating border-left the height of the corresponding container

## updated

- the start date input was missing the conditional `.has-error`
- fixed some minor layout issues
- fixed some typos
- refactored the password template