### PR TITLE
fix: make focus more visible

### DIFF
--- a/src/app/admin-dashboard/admin-dashboard.component.html
+++ b/src/app/admin-dashboard/admin-dashboard.component.html
@@ -81,7 +81,7 @@
             <div class="col">
               <div class="row">
                 <div class="col col-12">
-                  <a class="w-100" data-id="changePollLink" routerLink="/poll-admin">
+                  <a class="w-100 d-inline-block" data-id="changePollLink" routerLink="/poll-admin">
                     <img alt="Stift" class="icon" id="img_edit" src="assets/dashboard_edit.svg">
                     <span
                       class="d-block font-medium text-bold"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -27,7 +27,7 @@
         <li class="d-inline-block" ngbDropdown placement="bottom-right">
           <label class="sr-only" id="language">{{ 'lang.language' | translate }}</label>
           <button
-            class="btn outline-primary"
+            class="btn"
             data-id="languageDropdown"
             ngbDropdownToggle
             title="{{ 'lang.language' | translate }}"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -59,9 +59,9 @@
       Wichtige Bestandteile der Seite konnten nicht geladen werden. Bitte laden Sie die Seite neu!
     </ngb-toast>
   }
-  <main class="row g-0 py-4 justify-content-center" id="main">
+  <main class="row py-4 justify-content-center" id="main">
     <router-outlet></router-outlet>
   </main>
-  <div class="row g-0 d-none d-lg-flex" id="bottom-edge"></div>
+  <div class="row d-none d-lg-flex" id="bottom-edge"></div>
   <app-footer class="row justify-content-center py-2"></app-footer>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -27,7 +27,7 @@
         <li class="d-inline-block" ngbDropdown placement="bottom-right">
           <label class="sr-only" id="language">{{ 'lang.language' | translate }}</label>
           <button
-            class="btn"
+            class="btn outline-primary"
             data-id="languageDropdown"
             ngbDropdownToggle
             title="{{ 'lang.language' | translate }}"

--- a/src/app/create-suggested-dates/create-suggested-dates.component.html
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.html
@@ -33,7 +33,7 @@
           <span class="float-end">
             <button
               (click)="deleteSuggestedDateFormByIndex(i)"
-              class="btn btn-transparent p-0 border-0 btn-delete-date focus-outline"
+              class="btn btn-transparent p-0 border-0 btn-delete-date"
               id="removeDate-{{i}}"
               type="button"
             >
@@ -330,7 +330,7 @@
             <button
               (click)="showSuggestedDateEndDateOnDifferentDayForm(i)"
               [disabled]="isSuggestedDateFromDatabase(i)"
-              class="btn btn-default btn-transparent focus-outline btn-with-image btn-suggested-date-end-at-different-day font-weight-bold mt-1 mb-1"
+              class="btn btn-default btn-transparent btn-with-image btn-suggested-date-end-at-different-day font-weight-bold mt-1 mb-1"
               data-id="endAtOtherDayButton"
               type="button"
             >

--- a/src/app/create-suggested-dates/create-suggested-dates.component.html
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.html
@@ -33,7 +33,7 @@
           <span class="float-end">
             <button
               (click)="deleteSuggestedDateFormByIndex(i)"
-              class="btn btn-transparent p-0 border-0 btn-delete-date"
+              class="btn btn-transparent p-0 border-0 btn-delete-date focus-outline"
               id="removeDate-{{i}}"
               type="button"
             >
@@ -330,7 +330,7 @@
             <button
               (click)="showSuggestedDateEndDateOnDifferentDayForm(i)"
               [disabled]="isSuggestedDateFromDatabase(i)"
-              class="btn btn-default btn-transparent btn-with-image btn-suggested-date-end-at-different-day font-weight-bold mt-1 mb-1"
+              class="btn btn-default btn-transparent focus-outline btn-with-image btn-suggested-date-end-at-different-day font-weight-bold mt-1 mb-1"
               data-id="endAtOtherDayButton"
               type="button"
             >

--- a/src/app/create-suggested-dates/create-suggested-dates.component.scss
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.scss
@@ -74,6 +74,8 @@ form {
 }
 
 .btn-with-image.btn-suggested-date-end-at-different-day {
+  @include focus-outline;
+
   img {
     height: $height-icon;
     width: $width-icon;
@@ -166,12 +168,16 @@ input {
   }
 }
 
-.btn-delete-date img.icon {
-  height: $height-icon * 0.8;
-  width: $width-icon * 0.8;
-  @include media-breakpoint-up(lg) {
-    height: $height-icon;
-    width: $width-icon;
+.btn-delete-date {
+  @include focus-outline;
+
+  img.icon {
+    height: $height-icon * 0.8;
+    width: $width-icon * 0.8;
+    @include media-breakpoint-up(lg) {
+      height: $height-icon;
+      width: $width-icon;
+    }
   }
 }
 

--- a/src/app/create-suggested-dates/create-suggested-dates.component.scss
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.scss
@@ -74,6 +74,8 @@ form {
 }
 
 .btn-with-image.btn-suggested-date-end-at-different-day {
+  @include focus-outline;
+
   img {
     height: $height-icon;
     width: $width-icon;
@@ -167,6 +169,8 @@ input {
 }
 
 .btn-delete-date {
+  @include focus-outline;
+
   img.icon {
     height: $height-icon * 0.8;
     width: $width-icon * 0.8;

--- a/src/app/create-suggested-dates/create-suggested-dates.component.scss
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.scss
@@ -74,8 +74,6 @@ form {
 }
 
 .btn-with-image.btn-suggested-date-end-at-different-day {
-  @include focus-outline;
-
   img {
     height: $height-icon;
     width: $width-icon;
@@ -169,8 +167,6 @@ input {
 }
 
 .btn-delete-date {
-  @include focus-outline;
-
   img.icon {
     height: $height-icon * 0.8;
     width: $width-icon * 0.8;

--- a/src/app/links/links.component.html
+++ b/src/app/links/links.component.html
@@ -35,7 +35,7 @@
               {{ absoluteAppointmentLink }}
             </div>
           </div>
-          <div class="col-12 d-flex justify-content-end">
+          <div class="col-12 d-flex justify-content-end align-items-center">
             <button
               (click)="createPollMail()"
               class="btn btn-transparent text-primary"
@@ -93,7 +93,7 @@
               {{ absoluteAdminLink }}
             </div>
           </div>
-          <div class="col-12 d-flex justify-content-end">
+          <div class="col-12 d-flex justify-content-end align-items-center">
             <button
               (click)="createAdminMail()"
               class="btn btn-transparent text-primary"

--- a/src/app/overview/overview.component.html
+++ b/src/app/overview/overview.component.html
@@ -9,11 +9,11 @@
     {{ 'poll.checkData' | translate }}
   </h2>
 </div>
-<div class="row">
+<div class="row px-3">
   <div class="col">
     <div class="row">
       <div class="col">
-        <div class="section-container mx-3">
+        <div class="section-container">
           <div class="p-3">
             <app-appointment-summary [appointment]="model" [showDeleteWarning]="true"></app-appointment-summary>
           </div>

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -44,7 +44,7 @@
           <div class="col-auto px-1">
             <!-- button to delete the currently edited participant -->
             <button (click)="formHelper.deleteEditParticipant(getSelectedParticipant())"
-                    class="btn btn-transparent p-0 border-0"
+                    class="btn btn-trash btn-transparent p-0 border-0"
                     type="button">
               <img alt="trashcan" class="icon icon-delete" src="assets/trash.svg"/>
             </button>

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -44,7 +44,7 @@
           <div class="col-auto px-1">
             <!-- button to delete the currently edited participant -->
             <button (click)="formHelper.deleteEditParticipant(getSelectedParticipant())"
-                    class="btn btn-trash btn-transparent p-0 border-0"
+                    class="btn btn-trash btn-transparent focus-outline p-0 border-0"
                     type="button">
               <img alt="trashcan" class="icon icon-delete" src="assets/trash.svg"/>
             </button>

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container px-0">
   @if (formHelper.pollForm && formHelper.appointment) {
     <div [formGroup]="formHelper.pollForm"
          class="row g-0 toolbar d-lg-none p-1">

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -44,7 +44,7 @@
           <div class="col-auto px-1">
             <!-- button to delete the currently edited participant -->
             <button (click)="formHelper.deleteEditParticipant(getSelectedParticipant())"
-                    class="btn btn-trash btn-transparent focus-outline p-0 border-0"
+                    class="btn btn-trash btn-transparent p-0 border-0"
                     type="button">
               <img alt="trashcan" class="icon icon-delete" src="assets/trash.svg"/>
             </button>

--- a/src/app/poll/mobile-poll-table.component.scss
+++ b/src/app/poll/mobile-poll-table.component.scss
@@ -19,12 +19,7 @@
 }
 
 .btn.btn-trash {
-  outline: none;
-
-  &:focus {
-    outline: $primary solid 2px;
-    filter: brightness(50%);
-  }
+  @include focus-outline;
 }
 
 .poll-table td.suggested-date {

--- a/src/app/poll/mobile-poll-table.component.scss
+++ b/src/app/poll/mobile-poll-table.component.scss
@@ -18,6 +18,10 @@
   outline-offset: 0;
 }
 
+.btn.btn-trash {
+  @include focus-outline;
+}
+
 .poll-table td.suggested-date {
   width: 120px;
 }

--- a/src/app/poll/mobile-poll-table.component.scss
+++ b/src/app/poll/mobile-poll-table.component.scss
@@ -18,6 +18,15 @@
   outline-offset: 0;
 }
 
+.btn.btn-trash {
+  outline: none;
+
+  &:focus {
+    outline: $primary solid 2px;
+    filter: brightness(50%);
+  }
+}
+
 .poll-table td.suggested-date {
   width: 120px;
 }

--- a/src/app/poll/mobile-poll-table.component.scss
+++ b/src/app/poll/mobile-poll-table.component.scss
@@ -18,10 +18,6 @@
   outline-offset: 0;
 }
 
-.btn.btn-trash {
-  @include focus-outline;
-}
-
 .poll-table td.suggested-date {
   width: 120px;
 }

--- a/src/app/poll/mobile-poll-table.component.scss
+++ b/src/app/poll/mobile-poll-table.component.scss
@@ -15,6 +15,7 @@
   width: 45px;
   height: 100%;
   vertical-align: middle;
+  outline-offset: 0;
 }
 
 .poll-table td.suggested-date {

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -151,10 +151,10 @@
                           >
                         </div>
                         <!-- button to remove the form elements (so the participant won't be added) -->
-                        <div class="ml-2 col-auto">
+                        <div class="col-2 d-flex align-items-center justify-content-center">
                           <button
                             (click)="formHelper.deleteParticipantForm()"
-                            class="btn btn-round p-0 btn-transparent btn-trash w-100 h-100"
+                            class="btn btn-transparent btn-trash w-100 h-100 ml-auto mr-0"
                             data-id="deleteParticipantButton"
                             id="delete-new-participant"
                             type="button"
@@ -278,7 +278,7 @@
                           <div class="col-2 d-flex align-items-center justify-content-center">
                             <button
                               (click)="formHelper.deleteEditParticipant(participant)"
-                              class="btn btn-transparent btn-trash p-0 ml-auto mr-0"
+                              class="btn btn-transparent btn-trash w-100 h-100 ml-auto mr-0"
                               data-id="deleteEditedParticipantButton"
                               id="delete-edit-participant"
                               type="button"

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -388,7 +388,7 @@
               <div
                 class="col-3 d-inline-flex align-items-center justify-content-end text-right mr-4">
                 <img alt="" aria-hidden="true" class="circle-tag" src="assets/status_accepted.svg">
-                <div class="font-weight-bold voting-status-summary-added-participants" data-id="addedParticipation">
+                <div class="font-weight-bold voting-status-summary-added-participants pe-3" data-id="addedParticipation">
                   {{ formHelper.getNumberOfVotingsWithVotingStatusAcceptedOfAddedParticipant() | leadingZero: 2 }}
                 </div>
               </div>

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -154,7 +154,7 @@
                         <div class="col-2 d-flex align-items-center justify-content-center">
                           <button
                             (click)="formHelper.deleteParticipantForm()"
-                            class="btn btn-transparent btn-trash w-100 h-100 ml-auto mr-0"
+                            class="btn btn-transparent focus-outline btn-trash w-100 h-100 ml-auto mr-0"
                             data-id="deleteParticipantButton"
                             id="delete-new-participant"
                             type="button"
@@ -227,7 +227,7 @@
                           >
                             <button
                               (click)="formHelper.editParticipant(participant)"
-                              class="btn btn-transparent p-0 border-0"
+                              class="btn btn-transparent focus-outline p-0 border-0"
                               id="editButton-{{index}}"
                               type="button"
                             >
@@ -278,7 +278,7 @@
                           <div class="col-2 d-flex align-items-center justify-content-center">
                             <button
                               (click)="formHelper.deleteEditParticipant(participant)"
-                              class="btn btn-transparent btn-trash w-100 h-100 ml-auto mr-0"
+                              class="btn btn-transparent focus-outline btn-trash w-100 h-100 ml-auto mr-0"
                               data-id="deleteEditedParticipantButton"
                               id="delete-edit-participant"
                               type="button"
@@ -352,7 +352,7 @@
               <div class="d-flex justify-content-end">
                 <button
                   (click)="navigate(surveyLinkUser)"
-                  class="btn btn-transparent text-primary btn-with-image"
+                  class="btn btn-transparent focus-outline text-primary btn-with-image"
                   data-id="surveyLinkNavigate"
                   type="button"
                 >

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -154,7 +154,7 @@
                         <div class="col-2 d-flex align-items-center justify-content-center">
                           <button
                             (click)="formHelper.deleteParticipantForm()"
-                            class="btn btn-transparent focus-outline btn-trash w-100 h-100 ml-auto mr-0"
+                            class="btn btn-transparent btn-trash w-100 h-100 ml-auto mr-0"
                             data-id="deleteParticipantButton"
                             id="delete-new-participant"
                             type="button"
@@ -227,7 +227,7 @@
                           >
                             <button
                               (click)="formHelper.editParticipant(participant)"
-                              class="btn btn-transparent focus-outline p-0 border-0"
+                              class="btn btn-transparent p-0 border-0"
                               id="editButton-{{index}}"
                               type="button"
                             >
@@ -278,7 +278,7 @@
                           <div class="col-2 d-flex align-items-center justify-content-center">
                             <button
                               (click)="formHelper.deleteEditParticipant(participant)"
-                              class="btn btn-transparent focus-outline btn-trash w-100 h-100 ml-auto mr-0"
+                              class="btn btn-transparent btn-trash w-100 h-100 ml-auto mr-0"
                               data-id="deleteEditedParticipantButton"
                               id="delete-edit-participant"
                               type="button"
@@ -352,7 +352,7 @@
               <div class="d-flex justify-content-end">
                 <button
                   (click)="navigate(surveyLinkUser)"
-                  class="btn btn-transparent focus-outline text-primary btn-with-image"
+                  class="btn btn-transparent text-primary btn-with-image"
                   data-id="surveyLinkNavigate"
                   type="button"
                 >

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -58,17 +58,11 @@ img.icon {
 }
 
 button.btn-trash {
-  outline: none;
-
-  &:focus {
-    outline: $primary solid 2px;
-    filter: brightness(50%);
-  }
+  @include focus-outline;
 }
 
 .btn-transparent {
   @include focus-outline;
-  outline-offset: 5px;
 
   :hover {
     background-color: $medium-gray;

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -57,9 +57,17 @@ img.icon {
   height: 30px;
 }
 
-.btn-transparent:hover {
-  background-color: $medium-gray;
-  border-color: $medium-gray;
+button.btn-trash {
+  @include focus-outline;
+}
+
+.btn-transparent {
+  @include focus-outline;
+
+  :hover {
+    background-color: $medium-gray;
+    border-color: $medium-gray;
+  }
 }
 
 button.btn-with-image {

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -57,9 +57,14 @@ img.icon {
   height: 30px;
 }
 
-.btn-transparent:hover {
-  background-color: $medium-gray;
-  border-color: $medium-gray;
+.btn-transparent {
+  @include focus-outline;
+  outline-offset: 5px;
+
+  :hover {
+    background-color: $medium-gray;
+    border-color: $medium-gray;
+  }
 }
 
 button.btn-with-image {

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -57,6 +57,15 @@ img.icon {
   height: 30px;
 }
 
+button.btn-trash {
+  outline: none;
+
+  &:focus {
+    outline: $primary solid 2px;
+    filter: brightness(50%);
+  }
+}
+
 .btn-transparent {
   @include focus-outline;
   outline-offset: 5px;

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -57,17 +57,9 @@ img.icon {
   height: 30px;
 }
 
-button.btn-trash {
-  @include focus-outline;
-}
-
-.btn-transparent {
-  @include focus-outline;
-
-  :hover {
-    background-color: $medium-gray;
-    border-color: $medium-gray;
-  }
+.btn-transparent:hover {
+  background-color: $medium-gray;
+  border-color: $medium-gray;
 }
 
 button.btn-with-image {

--- a/src/app/shared/components/poll-options/poll-options.component.html
+++ b/src/app/shared/components/poll-options/poll-options.component.html
@@ -3,8 +3,8 @@
     [formGroup]="formGroup"
     class="row g-0 justify-content-end justify-content-lg-around align-items-center align-self-center max-content"
   >
-    <div class="col col-sm-auto">
-      <div class="row g-0 justify-content-center min-content">
+    <div class="col">
+      <div class="row g-0 justify-content-center">
         <div class="col-auto">
           <label
             class="form-check-label"
@@ -32,8 +32,8 @@
         </div>
       </div>
     </div>
-    <div class="col col-sm-auto">
-      <div class="row g-0 justify-content-center min-content">
+    <div class="col">
+      <div class="row g-0 justify-content-center">
         <div class="col-auto">
           <label
             class="w-100 form-check-label"
@@ -61,8 +61,8 @@
         </div>
       </div>
     </div>
-    <div class="col col-sm-auto">
-      <div class="row g-0 justify-content-center min-content">
+    <div class="col">
+      <div class="row g-0 justify-content-center">
         <div class="col-auto">
           <label
             class="form-check-label"

--- a/src/default.scss
+++ b/src/default.scss
@@ -101,6 +101,6 @@ $container-max-widths: (
   outline: none;
 
   &:focus {
-    outline: darken($primary, 50%) solid 3px !important;
+    outline: lighten($primary, 10%) solid 2px !important;
   }
 }

--- a/src/default.scss
+++ b/src/default.scss
@@ -96,3 +96,11 @@ $container-max-widths: (
   box-shadow: none;
   border: none;
 }
+
+@mixin focus-outline {
+  outline: none;
+
+  &:focus {
+    outline: lighten($primary, 10%) solid 0.25rem !important;
+  }
+}

--- a/src/default.scss
+++ b/src/default.scss
@@ -96,11 +96,3 @@ $container-max-widths: (
   box-shadow: none;
   border: none;
 }
-
-@mixin focus-outline {
-  outline: none;
-
-  &:focus {
-    outline: lighten($primary, 10%) solid 0.25rem !important;
-  }
-}

--- a/src/default.scss
+++ b/src/default.scss
@@ -101,6 +101,6 @@ $container-max-widths: (
   outline: none;
 
   &:focus {
-    outline: lighten($primary, 10%) solid 2px !important;
+    outline: lighten($primary, 10%) solid 0.25rem !important;
   }
 }

--- a/src/default.scss
+++ b/src/default.scss
@@ -96,3 +96,11 @@ $container-max-widths: (
   box-shadow: none;
   border: none;
 }
+
+@mixin focus-outline {
+  outline: none;
+
+  &:focus {
+    outline: darken($primary, 50%) solid 3px !important;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -131,6 +131,14 @@ a,
   outline-offset: .25rem;
 }
 
+.btn-secondary {
+  &:hover,
+  &:active,
+  &:focus {
+    background-color: $secondary !important;
+  }
+}
+
 .section-container {
   background-color: white;
   border-radius: $border-radius;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -116,7 +116,8 @@ input,
 textarea,
 select,
 button,
-a {
+a,
+.focus-outline {
   @include focus-outline;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -120,6 +120,10 @@ button.text-primary {
   @include focus-outline;
 }
 
+.btn-secondary:focus {
+  box-shadow: 0 0 0 .25rem darken($secondary, 15%);
+}
+
 .section-container {
   background-color: white;
   border-radius: $border-radius;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -116,13 +116,8 @@ input,
 textarea,
 select,
 button,
-a,
-.focus-outline {
-  outline: none;
-
-  &:focus {
-    outline: lighten($primary, 10%) solid 0.25rem !important;
-  }
+a {
+  @include focus-outline;
 }
 
 .btn-secondary:focus {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -112,6 +112,18 @@ input[type="radio"] {
   opacity: .5;
 }
 
+input,
+textarea,
+select,
+button.date,
+button.text-primary {
+  @include focus-outline;
+
+  &[type="text"] {
+    outline-offset: 5px;
+  }
+}
+
 .section-container {
   background-color: white;
   border-radius: $border-radius;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -126,6 +126,10 @@ a {
   outline-offset: .25rem;
 }
 
+.btn.outline-primary {
+  border-color: $primary;
+}
+
 .section-container {
   background-color: white;
   border-radius: $border-radius;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -115,13 +115,15 @@ input[type="radio"] {
 input,
 textarea,
 select,
-button.date,
-button.text-primary {
+button,
+a {
   @include focus-outline;
 }
 
 .btn-secondary:focus {
-  box-shadow: 0 0 0 .25rem darken($secondary, 15%);
+  box-shadow: none !important;
+  outline: .25rem solid $primary !important;
+  outline-offset: .25rem;
 }
 
 .section-container {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -118,10 +118,6 @@ select,
 button.date,
 button.text-primary {
   @include focus-outline;
-
-  &[type="text"] {
-    outline-offset: 5px;
-  }
 }
 
 .section-container {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -116,8 +116,13 @@ input,
 textarea,
 select,
 button,
-a {
-  @include focus-outline;
+a,
+.focus-outline {
+  outline: none;
+
+  &:focus {
+    outline: lighten($primary, 10%) solid 0.25rem !important;
+  }
 }
 
 .btn-secondary:focus {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -352,7 +352,7 @@ button.text-primary {
   background-origin: border-box;
   background-size: $form-status-icon-width-small auto;
   padding-right: $form-status-icon-width-small + 11px !important;
-  padding-left: $form-status-icon-width + 11px !important;
+  padding-left: $form-status-icon-width-small + 11px !important;
 
   &, &:active {
     background-image: url("/assets/next.svg") !important;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -131,10 +131,6 @@ a,
   outline-offset: .25rem;
 }
 
-.btn.outline-primary {
-  border-color: $primary;
-}
-
 .section-container {
   background-color: white;
   border-radius: $border-radius;


### PR DESCRIPTION
This PR improves the visible focus for each element a user can navigate to by keyboard.

- added missing focus indicator for `input`, `textarea`, `select`, `button.date`, `button.text-primary`
- added mixin for `:focus`

## smaller changes
- the trash icon had different styling on add/edit context, updated to use edit context
- fixed too much padding on the send button
- fixed mobile poll view, the row to add/edit a participant had unnecessary padding