### PR TITLE
feat: update table to be sticky for better cross-referencing

### DIFF
--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -85,17 +85,19 @@
           <tr class="text-center font-weight-normal">
             <!-- suggested date -->
             <td class="suggested-date pl-3">
-              <app-suggested-date [date]="date"></app-suggested-date>
-              <button
-                (click)="formHelper.downloadCal(date, i)"
-                class="download-cal btn btn-rounded btn-sm btn-light"
-                data-placement="top"
-                data-toggle="tooltip"
-                title="{{ 'poll.downloadIcs' | translate }}"
-                type="button"
-              >
-                <img alt="{{ 'poll.downloadIcs' | translate }}" aria-hidden="true" src="assets/download.svg">
-              </button>
+              <div class="d-flex justify-content-around align-items-center">
+                <app-suggested-date [date]="date"></app-suggested-date>
+                <button
+                  (click)="formHelper.downloadCal(date, i)"
+                  class="download-cal btn btn-rounded btn-sm btn-light"
+                  data-placement="top"
+                  data-toggle="tooltip"
+                  title="{{ 'poll.downloadIcs' | translate }}"
+                  type="button"
+                >
+                  <img alt="{{ 'poll.downloadIcs' | translate }}" aria-hidden="true" src="assets/download.svg">
+                </button>
+              </div>
             </td>
             <td class="total-participants">
               <div class="d-inline-block voting-status-summary-image text-center">

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -224,7 +224,7 @@
                     <!-- if the current row is not being edited just display the name & votes of the participant -->
                     @if (!formHelper.isEditInParticipantForm(participant.participantId)) {
                       <td class="pl-3">
-                        <div class="h-100 d-flex justify-content-between align-items-center">
+                        <div class="participant-container">
                           <!-- name -->
                           <span class="text-bold">{{ participant.name }}</span>
                           <!-- button to edit the participant -->
@@ -245,14 +245,16 @@
                         </div>
                       </td>
                       @for (date of model.suggestedDates; track date) {
-                        <td>
-                          <!--suppress HtmlUnknownTarget no inspection for this dynamic src path -->
-                          <img
-                            alt="voting-status"
-                            aria-hidden="true"
-                            class="mx-auto d-block poll-option-icon" src="assets/status_{{
-                  formHelper.getVotingStatusBySuggestedDateIdAndParticipantId(date.suggestedDateId, participant.participantId)
-                  }}.svg">
+                        <td class="height-1">
+                          <div class="h-100 d-flex align-items-center">
+                            <!--suppress HtmlUnknownTarget no inspection for this dynamic src path -->
+                            <img
+                              alt="voting-status"
+                              aria-hidden="true"
+                              class="mx-auto d-block poll-option-icon" src="assets/status_{{
+                    formHelper.getVotingStatusBySuggestedDateIdAndParticipantId(date.suggestedDateId, participant.participantId)
+                    }}.svg">
+                          </div>
                         </td>
                       }
                     }

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -223,24 +223,26 @@
                     [ngClass]="{'poll-edit-user-row': formHelper.isEditInParticipantForm(participant.participantId)}">
                     <!-- if the current row is not being edited just display the name & votes of the participant -->
                     @if (!formHelper.isEditInParticipantForm(participant.participantId)) {
-                      <td class="pl-3 align-middle">
-                        <!-- name -->
-                        <span class="ml-3 mt-1 float-start text-bold">{{ participant.name }}</span>
-                        <!-- button to edit the participant -->
-                        @if (!formHelper.hasAddParticipantForm() && !formHelper.hasEditParticipantForm() && !isAppointmentPaused) {
-                          <span
-                            class="float-end"
-                          >
-                            <button
-                              (click)="formHelper.editParticipant(participant)"
-                              class="btn btn-transparent p-0 border-0"
-                              id="editButton-{{index}}"
-                              type="button"
+                      <td class="pl-3">
+                        <div class="h-100 d-flex justify-content-between align-items-center">
+                          <!-- name -->
+                          <span class="text-bold">{{ participant.name }}</span>
+                          <!-- button to edit the participant -->
+                          @if (!formHelper.hasAddParticipantForm() && !formHelper.hasEditParticipantForm() && !isAppointmentPaused) {
+                            <span
+                              class="float-end"
                             >
-                              <img alt="pencil" class="icon icon-edit" src="assets/edit.svg"/>
-                            </button>
-                          </span>
-                        }
+                              <button
+                                (click)="formHelper.editParticipant(participant)"
+                                class="btn btn-transparent p-0 border-0"
+                                id="editButton-{{index}}"
+                                type="button"
+                              >
+                                <img alt="pencil" class="icon icon-edit" src="assets/edit.svg"/>
+                              </button>
+                            </span>
+                          }
+                        </div>
                       </td>
                       @for (date of model.suggestedDates; track date) {
                         <td>

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -245,7 +245,7 @@
                         </div>
                       </td>
                       @for (date of model.suggestedDates; track date) {
-                        <td class="height-1">
+                        <td class="td-full-height">
                           <div class="h-100 d-flex align-items-center">
                             <!--suppress HtmlUnknownTarget no inspection for this dynamic src path -->
                             <img

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -266,7 +266,7 @@ $poll-data-cell-invalid-message-min-height: 24px;
     width: 350px;
 
     &.name {
-      background: $toolbar-background-color;
+      background: $toolbar-background-color !important;
     }
 
     .invalid-message {

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -175,8 +175,11 @@ button.btn-with-image {
     }
   }
 
-  .height-1 {
+  .td-full-height {
     height: 1px; // https://stackoverflow.com/a/3542470/14700336
+    @supports (-moz-appearance:none) {
+      height: fit-content;
+    }
   }
 
   td.total-participants {

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -94,7 +94,7 @@ button.btn-with-image {
 .poll-table {
   display: block;
   overflow-x: auto;
-  white-space: nowrap;
+  white-space: pre-line;
   border: none;
 
   th.suggested-date {
@@ -131,6 +131,7 @@ button.btn-with-image {
 
   td {
     border-color: $poll-row-border-color;
+    height: min-content;
   }
 
   td.suggested-date {

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -68,11 +68,6 @@ tbody tr:last-child td {
   }
 }
 
-/*
-TODO
-table css aufräumen
- */
-
 .toolbar {
   background-color: $toolbar-background-color;
 }

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -168,6 +168,10 @@ button.btn-with-image {
     }
   }
 
+  .height-1 {
+    height: 1px; // https://stackoverflow.com/a/3542470/14700336
+  }
+
   td.total-participants {
     vertical-align: middle;
     font-size: 1.8rem;
@@ -175,9 +179,10 @@ button.btn-with-image {
     width: 50px;
   }
 
+  th,
   td {
     border-color: $poll-row-border-color;
-    height: min-content;
+    min-height: $poll-option-height-large;
   }
 
   td.suggested-date {
@@ -188,6 +193,16 @@ button.btn-with-image {
     width: $poll-option-width-large;
     height: $poll-option-width-large;
   }
+}
+
+.participant-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  height: 100%;
+  min-height: inherit;
+  overflow-wrap: anywhere;
 }
 
 .add-participant-form .form-group {

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -8,12 +8,25 @@ $icon-height: 30px;
   border: 1px solid #dee2e6 !important;
 }
 
-th {
-  border-width: 1px !important;
-}
-
+th,
 td {
   border-width: 1px !important;
+
+  &:first-child {
+    border-left: 0 !important;
+  }
+
+  &:last-child {
+    border-right: 0 !important;
+  }
+}
+
+thead tr:first-child th {
+  border-top: 0 !important;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0 !important;
 }
 
 .form-control {
@@ -21,6 +34,36 @@ td {
   @include media-breakpoint-up(lg) {
     font-size: $font-size-medium;
   }
+}
+
+// sticky header and first column
+thead tr {
+  position: sticky;
+  background: white;
+  z-index: 1;
+  top: 0;
+}
+
+tbody tr:first-child {
+  position: sticky;
+  background: white;
+  z-index: 1;
+  top: 135.4px; // smallest height of thead | dynamic value | different across browser-engines (+- .3px)
+}
+
+tbody tr > td:first-child:not(.poll-summary-row) {
+  position: sticky;
+  background: white;
+  z-index: 0;
+  left: 0;
+}
+
+thead th:first-child {
+  position: sticky;
+  background: white;
+  z-index: 1;
+  top: 0;
+  left: 0;
 }
 
 .toolbar {
@@ -95,7 +138,10 @@ button.btn-with-image {
   display: block;
   overflow-x: auto;
   white-space: pre-line;
-  border: none;
+  max-height: 100vh;
+  border: none !important;
+  border-collapse: separate;
+  border-spacing: 0;
 
   th.suggested-date {
     position: relative;

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -37,34 +37,41 @@ tbody tr:last-child td {
 }
 
 // sticky header and first column
-thead tr {
-  position: sticky;
-  background: white;
-  z-index: 1;
-  top: 0;
+@media (min-width: map-get($grid-breakpoints, lg)) {
+  thead tr {
+    position: sticky;
+    background: white;
+    z-index: 1;
+    top: 0;
+  }
+
+  tbody tr:first-child {
+    position: sticky;
+    background: white;
+    z-index: 1;
+    top: 135.4px; // smallest height of thead | dynamic value | different across browser-engines (+- .3px)
+  }
+
+  tbody tr > td:first-child:not(.poll-summary-row) {
+    position: sticky;
+    background: white;
+    z-index: 0;
+    left: 0;
+  }
+
+  thead th:first-child {
+    position: sticky;
+    background: white;
+    z-index: 1;
+    top: 0;
+    left: 0;
+  }
 }
 
-tbody tr:first-child {
-  position: sticky;
-  background: white;
-  z-index: 1;
-  top: 135.4px; // smallest height of thead | dynamic value | different across browser-engines (+- .3px)
-}
-
-tbody tr > td:first-child:not(.poll-summary-row) {
-  position: sticky;
-  background: white;
-  z-index: 0;
-  left: 0;
-}
-
-thead th:first-child {
-  position: sticky;
-  background: white;
-  z-index: 1;
-  top: 0;
-  left: 0;
-}
+/*
+TODO
+table css aufräumen
+ */
 
 .toolbar {
   background-color: $toolbar-background-color;


### PR DESCRIPTION
## Add
- sticky header
- sticky first body row
- sticky first column
- set table `max-height` to enable scrolling

## Update
- too long participant name now breaks line and increases the row height
Previous behaviour increased column width and moved the edit button into a new line
- change border-collapse because of missing borders in Firefox
- remove border-values of the outermost table borders, because else sticky position must relate to those values
- vertically center contents in `<td>`
- move download button next to date on mobile view