### PR TITLE
feat: add date description

### DIFF
--- a/backend-mock/server.js
+++ b/backend-mock/server.js
@@ -50,14 +50,14 @@ function isAuthenticated(isAdmin, requestAuth, appointment) {
   }
 }
 
-app.get('/api/app', (req, res) => {
+app.get('/app', (req, res) => {
   res.contentType(mediaType).status(200).json({
     "versionNumber": '0.5.0',
     "buildDate": '2020-10-01'
   });
 });
 
-app.post('/api/appointment/:customerId', (req, res) => {
+app.post('/appointment/:customerId', (req, res) => {
   const obj = {
     "appointmentId": uuid.v4(),
     "customerId": req.params.customerId,
@@ -90,7 +90,7 @@ app.post('/api/appointment/:customerId', (req, res) => {
   }
 });
 
-app.put('/api/appointment/:customerId', (req, res) => {
+app.put('/appointment/:customerId', (req, res) => {
   const obj = {
     "appointmentId": req.body.appointmentId,
     "customerId": req.params.customerId,
@@ -123,7 +123,7 @@ app.put('/api/appointment/:customerId', (req, res) => {
   }
 });
 
-app.get('/api/appointment/:customerId/:appointmentId/protection', (req, res) => {
+app.get('/appointment/:customerId/:appointmentId/protection', (req, res) => {
   const obj = {
     'appointmentId': req.params.appointmentId,
     'customerId': req.params.customerId
@@ -140,7 +140,7 @@ app.get('/api/appointment/:customerId/:appointmentId/protection', (req, res) => 
   }
 });
 
-app.get('/api/appointment/:customerId/:appointmentId/passwordverification', (req, res) => {
+app.get('/appointment/:customerId/:appointmentId/passwordverification', (req, res) => {
   const obj = {
     'appointmentId': req.params.appointmentId,
     'customerId': req.params.customerId
@@ -177,7 +177,7 @@ function shuffle(array) {
   return array;
 }
 
-app.get('/api/appointment/:customerId/:appointmentId', (req, res) => {
+app.get('/appointment/:customerId/:appointmentId', (req, res) => {
   const obj = {
     'appointmentId': req.params.appointmentId,
     'customerId': req.params.customerId
@@ -199,7 +199,7 @@ app.get('/api/appointment/:customerId/:appointmentId', (req, res) => {
   }
 });
 
-app.get('/api/admin/:customerId/:adminId/protection', (req, res) => {
+app.get('/admin/:customerId/:adminId/protection', (req, res) => {
   const obj = {
     'adminId': req.params.adminId,
     'customerId': req.params.customerId
@@ -216,7 +216,7 @@ app.get('/api/admin/:customerId/:adminId/protection', (req, res) => {
   }
 });
 
-app.get('/api/admin/:customerId/:adminId/passwordverification', (req, res) => {
+app.get('/admin/:customerId/:adminId/passwordverification', (req, res) => {
   const obj = {
     'adminId': req.params.adminId,
     'customerId': req.params.customerId
@@ -234,7 +234,7 @@ app.get('/api/admin/:customerId/:adminId/passwordverification', (req, res) => {
   }
 });
 
-app.get('/api/admin/:customerId/:adminId', (req, res) => {
+app.get('/admin/:customerId/:adminId', (req, res) => {
   let obj = {
     'adminId': req.params.adminId,
     'customerId': req.params.customerId
@@ -249,7 +249,7 @@ app.get('/api/admin/:customerId/:adminId', (req, res) => {
   }
 });
 
-app.put('/api/admin/:customerId/:adminId/paused/status', (req, res) => {
+app.put('/admin/:customerId/:adminId/paused/status', (req, res) => {
   let obj = {
     'adminId': req.params.adminId,
     'customerId': req.params.customerId
@@ -266,7 +266,7 @@ app.put('/api/admin/:customerId/:adminId/paused/status', (req, res) => {
   }
 });
 
-app.put('/api/admin/:customerId/:adminId/started/status', (req, res) => {
+app.put('/admin/:customerId/:adminId/started/status', (req, res) => {
   let obj = {
     'adminId': req.params.adminId,
     'customerId': req.params.customerId
@@ -283,7 +283,7 @@ app.put('/api/admin/:customerId/:adminId/started/status', (req, res) => {
   }
 });
 
-app.put('/api/votings/:customerId/:appointmentId', (req, res) => {
+app.put('/votings/:customerId/:appointmentId', (req, res) => {
   let obj = {
     "appointmentId": req.params.appointmentId,
     "customerId": req.params.customerId,

--- a/cypress/e2e/create-dates-view.cy.ts
+++ b/cypress/e2e/create-dates-view.cy.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 import * as dayjs from 'dayjs';
 import * as utc from 'dayjs/plugin/utc';
+import values from "../fixtures/values.json";
 
 dayjs.extend(utc);
 
@@ -20,6 +21,8 @@ context('create-dates-view', () => {
       cy.get('[data-id=startDateInput]');
       cy.get('[data-id=addTimesButton]');
       cy.get('[data-id=endAtOtherDayButton]');
+      cy.get('[data-id=descriptionLabel]');
+      cy.get('[data-id=descriptionInput]');
       cy.get('[data-id=addSuggestedDateButton]');
       cy.get('[data-id=back]')
         .should('be.enabled');
@@ -318,6 +321,18 @@ context('create-dates-view', () => {
         .clear();
     });
 
+    it('Accepts valid description', () => {
+      cy.get('[data-id=descriptionInput]')
+        .type('Test-Beschreibung', {delay: 0})
+        .should('have.value', 'Test-Beschreibung');
+    });
+
+    it('Does not accept too long description', () => {
+      cy.get('[data-id=descriptionTooLong]').should('not.exist');
+      cy.get('[data-id=descriptionInput]')
+        .type(values.tooLongString, {delay: 0});
+      cy.get('[data-id=descriptionTooLong]');
+    });
   });
 
   describe('Adds new suggested date', () => {

--- a/src/app/create-suggested-dates/create-suggested-dates.component.html
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.html
@@ -553,10 +553,9 @@
           </div>
         </div>
         <!-- error messages for this date entry -->
-        @if (getSuggestedDatesForm(i).invalid) {
+        @if (getSuggestedDatesForm(i).dirty && !!getSuggestedDatesForm(i).errors) {
           <div class="row mb-2">
-            <div [ngClass]="{'has-error': getSuggestedDatesForm(i).invalid
-                  && (getSuggestedDatesForm(i).dirty || getSuggestedDatesForm(i).touched)}"
+            <div [ngClass]="{'has-error': getSuggestedDatesForm(i).invalid}"
                  class="col my-1 px-1 px-lg-3 my-1 form-group">
               @if (!!getSuggestedDatesForm(i).errors?.startDateAfterEndDate) {
                 <div class="invalid-message" id="start-date-after-end-date">

--- a/src/app/create-suggested-dates/create-suggested-dates.component.html
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.html
@@ -541,7 +541,7 @@
                 formControlName="description"
                 placeholder="{{ 'poll.details.description.description' | translate }}"
                 type="text"
-                aria-describedby="maxLength-description"
+                aria-describedby="description-too-long"
               >
             </div>
             @if (!!getDescriptionByIndex(i).invalid) {

--- a/src/app/create-suggested-dates/create-suggested-dates.component.html
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.html
@@ -517,6 +517,41 @@
             }
           </div>
         }
+        <div class="my-2 divider-single"></div>
+        <!-- description (optional) for this date entry -->
+        <div class="row">
+          <div
+            [ngClass]="{'has-error': getDescriptionByIndex(i).invalid
+              && (getDescriptionByIndex(i).dirty || getDescriptionByIndex(i).touched)}"
+            class="col form-group invalid-message-highlight"
+          >
+            <label data-id="descriptionLabel" for="suggested-date-description-{{i}}">
+              {{ 'poll.details.description.descriptionOptional' | translate }}
+            </label>
+            <div class="input-group">
+              <div class="input-group-prepend">
+                <div class="input-group-text input-group-divider">
+                  <img ngSrc="assets/description.svg" alt="Sprechblase" height="height" width="width">
+                </div>
+              </div>
+              <input
+                id="suggested-date-description-{{i}}"
+                data-id="descriptionInput"
+                class="form-control"
+                formControlName="description"
+                placeholder="{{ 'poll.details.description.description' | translate }}"
+                type="text"
+                aria-describedby="maxLength-description"
+              >
+            </div>
+            @if (!!getDescriptionByIndex(i).invalid) {
+              <div class="invalid-message" id="description-too-long" data-id="descriptionTooLong">
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                {{ 'poll.details.description.tooLong' | translate }}
+              </div>
+            }
+          </div>
+        </div>
         <!-- error messages for this date entry -->
         @if (getSuggestedDatesForm(i).invalid) {
           <div class="row mb-2">

--- a/src/app/create-suggested-dates/create-suggested-dates.component.scss
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.scss
@@ -76,6 +76,10 @@ form {
 .btn-with-image.btn-suggested-date-end-at-different-day {
   @include focus-outline;
 
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
   img {
     height: $height-icon;
     width: $width-icon;

--- a/src/app/create-suggested-dates/create-suggested-dates.component.ts
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.ts
@@ -47,6 +47,7 @@ export class CreateSuggestedDatesComponent implements OnInit {
     SuggestedDatesFormConstants.FORM_KEY_SUGGESTED_DATE_SHOW_END_DATE_END_TIME;
   public static readonly FORM_KEY_SUGGESTED_DATE_SHOW_SUGGESTED_START_DATE_ON_DIFFERENT_DAY_FORM =
     SuggestedDatesFormConstants.FORM_KEY_SUGGESTED_DATE_SHOW_SUGGESTED_START_DATE_ON_DIFFERENT_DAY_FORM;
+  public static readonly FORM_KEY_SUGGESTED_DATE_DESCRIPTION = SuggestedDatesFormConstants.FORM_KEY_SUGGESTED_DATE_DESCRIPTION;
 
   @Input() isAdmin = false;
   mobiledetect = new MobileDetect(window.navigator.userAgent);
@@ -187,6 +188,11 @@ export class CreateSuggestedDatesComponent implements OnInit {
 
   public getShowSuggestedDateEndDateOnDifferentDayFormValue(index: number): boolean {
     return this.getShowSuggestedDateEndDateOnDifferentDayForm(index).value as boolean;
+  }
+
+  public getDescriptionByIndex(index: number): AbstractControl {
+    return this.getSuggestedDatesForm(index)
+      .get(CreateSuggestedDatesComponent.FORM_KEY_SUGGESTED_DATE_DESCRIPTION) as AbstractControl;
   }
 
   public getShowStartDateStartTimeControl(index: number): AbstractControl {
@@ -337,6 +343,9 @@ export class CreateSuggestedDatesComponent implements OnInit {
         ValidatorUtils.parseMomentFromIsoString(suggestedDate.endTime, this.localeId),
         this.localeId)
       : null;
+    const descriptionValue: string = suggestedDateSubmitted && !NullableUtils.isStringNullOrWhitespace(suggestedDate.description)
+      ? suggestedDate.description.trim()
+      : null;
 
     return new UntypedFormGroup({
       [SuggestedDatesFormConstants.FORM_KEY_SUGGESTED_DATE_ID]: new UntypedFormControl(suggestedDateIdValue),
@@ -371,7 +380,9 @@ export class CreateSuggestedDatesComponent implements OnInit {
         },
         [timeValidator(this.localeId)]),
       [SuggestedDatesFormConstants.FORM_KEY_SUGGESTED_DATE_SHOW_END_DATE_END_TIME]: new UntypedFormControl(false),
-      [SuggestedDatesFormConstants.FORM_KEY_SUGGESTED_DATE_SHOW_SUGGESTED_START_DATE_ON_DIFFERENT_DAY_FORM]: new UntypedFormControl(endDateValue !== null)
+      [SuggestedDatesFormConstants.FORM_KEY_SUGGESTED_DATE_SHOW_SUGGESTED_START_DATE_ON_DIFFERENT_DAY_FORM]: new UntypedFormControl(endDateValue !== null),
+      [SuggestedDatesFormConstants.FORM_KEY_SUGGESTED_DATE_DESCRIPTION]: new UntypedFormControl(descriptionValue,
+        [Validators.maxLength(ValidatorConstants.MAX_LENGTH_DATE_DESCRIPTION)]),
     }, [suggestedDateValidator(this.localeId, this.dateTimeGenerator)]);
   }
 
@@ -403,6 +414,7 @@ export class CreateSuggestedDatesComponent implements OnInit {
     itemToAdd.endTime = !NullableUtils.isStringNullOrEmpty(endTimeAsString)
       ? this.createSerializedDateTimeFromString(endDate === null ? startDate : endDate, endTimeAsString)
       : null;
+    itemToAdd.description = this.getDescriptionByIndex(index).value;
     return itemToAdd;
   }
 

--- a/src/app/create-suggested-dates/suggested-dates-form-constants.ts
+++ b/src/app/create-suggested-dates/suggested-dates-form-constants.ts
@@ -11,4 +11,5 @@ export class SuggestedDatesFormConstants {
   public static readonly FORM_KEY_SUGGESTED_DATE_SHOW_END_DATE_END_TIME = 'showEndDateEndTime';
   public static readonly FORM_KEY_SUGGESTED_DATE_SHOW_SUGGESTED_START_DATE_ON_DIFFERENT_DAY_FORM =
     'showSuggestedStartDateOnDifferentDayForm';
+  public static readonly FORM_KEY_SUGGESTED_DATE_DESCRIPTION = 'description';
 }

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -89,8 +89,11 @@
           <tr class="text-center font-weight-normal">
             <!-- suggested date -->
             <td class="suggested-date pl-3">
-              <div class="d-flex justify-content-around align-items-center">
-                <app-suggested-date [date]="date"></app-suggested-date>
+              <div class="row g-0">
+                <div class="col-9">
+                  <app-suggested-date [date]="date"></app-suggested-date>
+                </div>
+                <div class="col-3 d-flex justify-content-center align-items-center">
                 <button
                   (click)="formHelper.downloadCal(date, i)"
                   class="download-cal btn btn-rounded btn-sm btn-light"
@@ -101,6 +104,7 @@
                 >
                   <img alt="{{ 'poll.downloadIcs' | translate }}" aria-hidden="true" src="assets/download.svg">
                 </button>
+                </div>
               </div>
             </td>
             <td class="total-participants">

--- a/src/app/poll/mobile-poll-table.component.scss
+++ b/src/app/poll/mobile-poll-table.component.scss
@@ -23,7 +23,7 @@
 }
 
 .poll-table td.suggested-date {
-  width: 120px;
+  width: 150px;
 }
 
 .toolbar {

--- a/src/app/poll/poll-form-helper.service.spec.ts
+++ b/src/app/poll/poll-form-helper.service.spec.ts
@@ -38,6 +38,7 @@ describe("PollFormHelperService", () => {
         startTime: "2024-01-10T12:00:00.000Z",
         endDate: "2024-01-11T00:00:00.000Z",
         endTime: "2024-01-11T06:00:00.000Z",
+        description: "description"
       },
       {
         suggestedDateId: "2",
@@ -45,6 +46,7 @@ describe("PollFormHelperService", () => {
         startTime: "2024-01-20T13:00:00.000Z",
         endDate: "",
         endTime: "2024-01-21T18:00:00.000Z",
+        description: "a different description"
       },
     ];
 

--- a/src/app/poll/poll-form-helper.service.ts
+++ b/src/app/poll/poll-form-helper.service.ts
@@ -181,6 +181,10 @@ export class PollFormHelperService {
 
     let description = this.appointment.description;
 
+    if (date.description) {
+      description += '\n\r\n\r' + date.description;
+    }
+
     const acceptingParticipants = this.getParticipantsWithVotingsOnSuggestedDate(date.suggestedDateId, VotingStatusType.Accepted);
     description += generateDescription(description.length, acceptingParticipants, 'Zugesagt:');
 

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -1,6 +1,6 @@
 <div class="row g-0 justify-content-center text-center suggested-date-container">
   <!-- column on the left or centered with start date and - for desktop resolutions - start and end time  -->
-  <div class="col-5 column">
+  <div class="col-5 column position-relative">
     <!-- start date -->
     <div>{{ date.startDate | date:'MMM': '': getLocale() | slice: 0:3 }}</div>
     <div class="day">{{ date.startDate | date:'dd': '': getLocale() }}</div>
@@ -15,7 +15,7 @@
     - on a desktop (lg+) device AND
     - if there's no end date  -->
     <div [ngClass]="{'d-lg-block': date.endTime && !date.endDate}" class="position-absolute d-none hyphen"
-         style="left: 26px; bottom: 8px;">-
+         style="left: 26px; bottom: 6px;">-
     </div>
     <div [ngClass]="{'d-lg-block': date.endTime && !date.endDate}"
          class="d-none">{{ date.endTime | date:'HH:mm': '': getLocale() }}
@@ -26,7 +26,7 @@
     <div class="col-auto align-self-center d-lg-none">
       <div class="ml-1 mr-2 d-inline-block date-time-divider"></div>
     </div>
-    <div class="col d-flex d-lg-none column">
+    <div class="col d-flex d-lg-none column position-relative">
       <div class="row g-0 align-self-center w-100">
         <div class="col">
           <div>{{ date.startTime | date:'HH:mm': '': getLocale() }}</div>
@@ -36,7 +36,7 @@
         </div>
       </div>
       @if (date.endTime) {
-        <div class="position-absolute d-lg-none hyphen" style="left: 19px; top: 13px;">
+        <div class="position-absolute d-lg-none hyphen" style="left: 29px; top: 15px;">
           -
         </div>
       }

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -1,4 +1,4 @@
-<div class="row g-0 justify-content-center text-center suggested-date-container">
+<div class="row g-0 mb-1 justify-content-center text-center suggested-date-container">
   <!-- column on the left or centered with start date and - for desktop resolutions - start and end time  -->
   <div class="col-5 column position-relative">
     <!-- start date -->
@@ -67,7 +67,7 @@
           {{ date.description }}
         </details>
       } @else {
-        <p>{{ date.description }}</p>
+        <span>{{ date.description }}</span>
       }
     </div>
   }

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -14,8 +14,9 @@
     <!-- display hyphen and endTime if:
     - on a desktop (lg+) device AND
     - if there's no end date  -->
-    <div [ngClass]="{'d-lg-block': date.endTime && !date.endDate}" class="position-absolute d-none hyphen"
-         style="left: 26px; bottom: 6px;">-
+    <div [ngClass]="{'d-lg-block': date.endTime && !date.endDate}"
+         class="position-absolute d-none hyphen start-0 end-0">
+      -
     </div>
     <div [ngClass]="{'d-lg-block': date.endTime && !date.endDate}"
          class="d-none">{{ date.endTime | date:'HH:mm': '': getLocale() }}
@@ -31,15 +32,15 @@
         <div class="col">
           <div>{{ date.startTime | date:'HH:mm': '': getLocale() }}</div>
         </div>
-        <div class="col">
-          <div>{{ date.endTime | date:'HH:mm': '': getLocale() }}</div>
-        </div>
+        @if (date.endTime) {
+          <div class="col">
+            <div>{{ date.endTime | date:'HH:mm': '': getLocale() }}</div>
+          </div>
+          <div class="position-absolute d-lg-none hyphen start-0 end-0">
+            -
+          </div>
+        }
       </div>
-      @if (date.endTime) {
-        <div class="position-absolute d-lg-none hyphen" style="left: 29px; top: 15px;">
-          -
-        </div>
-      }
     </div>
   }
   <!-- column on the right for end date and end time -->

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -56,4 +56,19 @@
       }
     </div>
   }
+  <!-- description for this date -->
+  @if (date.description) {
+    <div class="description text-center">
+      @if (date.description.length > 13) {
+        <details>
+          <summary>
+            {{ 'poll.details.description.description' | translate }}
+          </summary>
+          {{ date.description }}
+        </details>
+      } @else {
+        <p>{{ date.description }}</p>
+      }
+    </div>
+  }
 </div>

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -6,10 +6,10 @@
     <div class="day">{{ date.startDate | date:'dd': '': getLocale() }}</div>
     <div>{{ date.startDate | date:'E': '': getLocale() | slice: 0:2 }}</div>
     <!-- display start time here if:
-    - on a desktop (lg+) device OR
-    - if there's also an end date  -->
-    <div [ngClass]="{'d-block': date.endDate}"
-         class="d-none d-lg-block">{{ date.startTime | date:'HH:mm': '': getLocale() }}
+      - there's an end date OR
+      - on a desktop (lg+) device -->
+    <div [ngClass]="{'d-none': !date.endDate}"
+         class="d-lg-block">{{ date.startTime | date:'HH:mm': '': getLocale() }}
     </div>
     <!-- display hyphen and endTime if:
     - on a desktop (lg+) device AND

--- a/src/app/shared/components/suggested-date/suggested-date.component.scss
+++ b/src/app/shared/components/suggested-date/suggested-date.component.scss
@@ -22,6 +22,16 @@ div {
 
 .hyphen {
   font-size: 25px;
+
+  // desktop
+  &.position-absolute.d-lg-block {
+    bottom: 0.375rem;
+  }
+
+  // mobile
+  &.position-absolute.d-lg-none {
+    bottom: 1rem;
+  }
 }
 
 .suggested-date-container .column {

--- a/src/app/shared/components/suggested-date/suggested-date.component.scss
+++ b/src/app/shared/components/suggested-date/suggested-date.component.scss
@@ -28,6 +28,17 @@ div {
   font-size: $font-size-small;
 }
 
+.description {
+  font-size: medium;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  word-break: break-word;
+
+  summary {
+    font-size: small;
+  }
+}
+
 .suggested-date-container {
   @include media-breakpoint-up(lg) {
     min-width: $suggested-date-desktop-min-width;

--- a/src/app/shared/constants/validatorConstants.ts
+++ b/src/app/shared/constants/validatorConstants.ts
@@ -14,6 +14,7 @@ export class ValidatorConstants {
   public static readonly MAX_LENGTH_DESCRIPTION = 1500;
   public static readonly MIN_NUMBER_SUGGESTED_DATES = 1;
   public static readonly MAX_NUMBER_SUGGESTED_DATES = 100;
+  public static readonly MAX_LENGTH_DATE_DESCRIPTION = 100;
   public static readonly MOMENT_FORMAT_DATE = 'DD.MM.YYYY';
   public static readonly MOMENT_FORMAT_DATE_VARIATIONS = [
     'DD.MM.YYYY',

--- a/src/app/shared/models/api-data-v1-dto/suggestedDate.ts
+++ b/src/app/shared/models/api-data-v1-dto/suggestedDate.ts
@@ -4,4 +4,5 @@ export class SuggestedDate {
   startTime: string;
   endDate: string;
   endTime: string;
+  description: string;
 }

--- a/src/app/shared/models/suggestedDate.ts
+++ b/src/app/shared/models/suggestedDate.ts
@@ -4,4 +4,5 @@ export class SuggestedDate {
   startTime: string;
   endDate: string;
   endTime: string;
+  description: string;
 }

--- a/src/app/shared/services/transformer/model-transformer.service.ts
+++ b/src/app/shared/services/transformer/model-transformer.service.ts
@@ -82,7 +82,8 @@ export class ModelTransformerService {
       startDate: startMoment.format(ApiConstants.MOMENT_FORMAT_DATE),
       startTime: !NullableUtils.isObjectNullOrUndefined(suggestedDate.startTime) ? startMoment.format(ApiConstants.MOMENT_FORMAT_TIME) : null,
       endDate: setEndDate ? endMoment.format(ApiConstants.MOMENT_FORMAT_DATE) : null,
-      endTime: !NullableUtils.isObjectNullOrUndefined(suggestedDate.endTime) ? endMoment.format(ApiConstants.MOMENT_FORMAT_TIME) : null
+      endTime: !NullableUtils.isObjectNullOrUndefined(suggestedDate.endTime) ? endMoment.format(ApiConstants.MOMENT_FORMAT_TIME) : null,
+      description: !NullableUtils.isStringNullOrWhitespace(suggestedDate.description) ? suggestedDate.description : null
     } as ApiSuggestedDate;
   }
 
@@ -252,7 +253,8 @@ export class ModelTransformerService {
       startTime: !NullableUtils.isObjectNullOrUndefined(suggestedDate.startTime) ? startMoment.local().format() : null,
       endDate: (!NullableUtils.isObjectNullOrUndefined(suggestedDate.endDate) || !NullableUtils.isObjectNullOrUndefined(suggestedDate.endTime))
       && startDateDifferentFromEndDate ? endMoment.local().format(ApiConstants.MOMENT_FORMAT_DATE) : null,
-      endTime: !NullableUtils.isObjectNullOrUndefined(suggestedDate.endTime) ? endMoment.local().format() : null
+      endTime: !NullableUtils.isObjectNullOrUndefined(suggestedDate.endTime) ? endMoment.local().format() : null,
+      description: !NullableUtils.isStringNullOrWhitespace(suggestedDate.description) ? suggestedDate.description : null
     } as ApiSuggestedDate;
   }
 

--- a/src/proxy.conf.json
+++ b/src/proxy.conf.json
@@ -3,6 +3,7 @@
     "target": "http://localhost:4201",
     "secure": false,
     "logLevel": "debug",
-    "changeOrigin": true
+    "changeOrigin": true,
+    "pathRewrite": {"^/api" : ""}
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -149,11 +149,13 @@ a,
   @include focus-outline;
 }
 
-.btn-secondary:focus,
-.btn-primary:focus {
-  box-shadow: none !important;
-  outline: .25rem solid $primary !important;
-  outline-offset: .25rem;
+.btn-primary,
+.btn-secondary {
+  &:focus {
+    box-shadow: none !important;
+    outline: .25rem solid $primary !important;
+    outline-offset: .25rem;
+  }
 }
 
 .btn-secondary {


### PR DESCRIPTION
- add description for each suggested date
- update e2e-tests
- update error container on date creation to first exist when an error is made
Previously the container always existed, adding unwanted whitespace. Upon clearing the error the container always stops being displayed.
- fix start time sometimes missing
- fix hyphen position between start & endtime
- fix missing outline-offset on back-button
- refactor the proxy settings for backend-mock