### PR TITLE
fix: screenreaders can't answer poll in firefox

### DIFF
--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -41,8 +41,7 @@
             <!-- mobile table -->
             <app-mobile-poll-table></app-mobile-poll-table>
             <!-- desktop table -->
-            <table aria-hidden="true"
-                   class="table table-striped table-hover mb-0 bordered poll-table d-none d-lg-block">
+            <table class="table table-striped table-hover mb-0 bordered poll-table d-none d-lg-block">
               <!-- first row contains the suggested dates -->
               <thead class="h-100" data-id="tableHead">
               <tr class="h-100">


### PR DESCRIPTION
- remove `aria-hidden` attribute

fixes #304