### PR TITLE
Fix/table structure accessibility

### DIFF
--- a/cypress/e2e/poll-view.cy.ts
+++ b/cypress/e2e/poll-view.cy.ts
@@ -185,18 +185,12 @@ context('poll-view', () => {
       cy.get('[data-id=addParticipantButton]')
         .click();
 
-      cy.get('#desktop-label-status-declined-0');
       cy.get('#desktop-voting-status-declined-0');
-      cy.get('#desktop-label-status-questionable-0');
       cy.get('#desktop-voting-status-questionable-0');
-      cy.get('#desktop-label-status-accepted-0');
       cy.get('#desktop-voting-status-accepted-0');
 
-      cy.get('#desktop-label-status-declined-1');
       cy.get('#desktop-voting-status-declined-1');
-      cy.get('#desktop-label-status-questionable-1');
       cy.get('#desktop-voting-status-questionable-1');
-      cy.get('#desktop-label-status-accepted-1');
       cy.get('#desktop-voting-status-accepted-1');
     });
 

--- a/src/app/create-appointment/create-appointment.component.html
+++ b/src/app/create-appointment/create-appointment.component.html
@@ -32,7 +32,8 @@
                 required
                 class="form-control"
                 data-id="titleInput"
-                formControlName="title" id="title"
+                formControlName="title"
+                id="title"
                 placeholder="{{ 'poll.title.title' | translate }}"
                 type="text"
                 aria-describedby="required-title invalid-title maxLength-title">

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -108,11 +108,13 @@
               </div>
             </td>
             <td class="total-participants">
-              <div class="d-inline-block voting-status-summary-image text-center">
-                <img alt="checkmark" aria-hidden="true" src="assets/status_accepted.svg">
-              </div>
-              <div class="font-weight-bold d-inline-block voting-status-summary-number">
-                {{ formHelper.getNumberOfAcceptedVotingsBySuggestedDate(date.suggestedDateId) }}
+              <div class="mx-4 d-flex justify-content-between align-items-center">
+                <div class="voting-status-summary-image">
+                  <img alt="checkmark" aria-hidden="true" src="assets/status_accepted.svg">
+                </div>
+                <div class="font-weight-bold voting-status-summary-number mx-1">
+                  {{ formHelper.getNumberOfAcceptedVotingsBySuggestedDate(date.suggestedDateId) }}
+                </div>
               </div>
             </td>
             <td class="poll-options pr-2">

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -91,7 +91,7 @@
             <td class="suggested-date pl-3">
               <div class="row g-0">
                 <div class="col-9">
-                  <app-suggested-date [date]="date"></app-suggested-date>
+                  <app-suggested-date [date]="date" [index]="i"></app-suggested-date>
                 </div>
                 <div class="col-3 d-flex justify-content-center align-items-center">
                 <button

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -145,6 +145,29 @@
           </tr>
         }
       </tbody>
+      <tfoot class="d-table w-100">
+      <tr>
+        <td class="p-2">
+          <div class="d-flex justify-content-center align-items-center">
+            <button
+              (click)="formHelper.downloadCsv()"
+              class="download-csv btn btn-rounded btn-sm btn-light"
+              data-id="downloadCsvButton"
+              data-placement="top"
+              data-toggle="tooltip"
+              id="download-csv"
+              title="{{ 'poll.downloadCsv' | translate }}"
+              type="button"
+            >
+              <img alt="" aria-hidden="true" src="assets/calendar_grey.svg">
+            </button>
+            <span class="font-small ms-2">
+              {{ 'poll.downloadCsvDescription' | translate }}
+            </span>
+          </div>
+        </td>
+      </tr>
+      </tfoot>
     </table>
   }
 </div>

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -90,10 +90,10 @@
             <!-- suggested date -->
             <td class="suggested-date pl-3">
               <div class="row g-0">
-                <div class="col-9">
+                <div class="col-8">
                   <app-suggested-date [date]="date" [index]="i"></app-suggested-date>
                 </div>
-                <div class="col-3 d-flex justify-content-center align-items-center">
+                <div class="col-4 d-flex justify-content-center align-items-center">
                 <button
                   (click)="formHelper.downloadCal(date, i)"
                   class="download-cal btn btn-rounded btn-sm btn-light"

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -123,8 +123,11 @@
                 <img
                   alt="voting-status" aria-hidden="true"
                   class="my-auto mr-3 ml-auto d-block poll-option-icon"
-                  src="assets/status_{{ formHelper.getVotingStatusBySuggestedDateIdAndParticipantId(
-          date.suggestedDateId, getSelectedParticipant().participantId)}}.svg">
+                  src="assets/status_{{
+                    formHelper.getVotingStatusBySuggestedDateIdAndParticipantId(
+                      date.suggestedDateId,
+                      getSelectedParticipant().participantId)
+                    }}.svg">
               }
               @if (formHelper.hasAddOrEditParticipantForm()) {
                 @for (voting of formHelper.getParticipantFormVotings().controls; track voting; let j = $index) {

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -155,7 +155,7 @@
             <button
               (click)="formHelper.downloadCsv()"
               class="download-csv btn btn-rounded btn-sm btn-light"
-              data-id="downloadCsvButton"
+              data-id="downloadCsvButtonMobile"
               data-placement="top"
               data-toggle="tooltip"
               id="download-csv"

--- a/src/app/poll/mobile-poll-table.component.scss
+++ b/src/app/poll/mobile-poll-table.component.scss
@@ -4,10 +4,14 @@
   appearance: auto
 }
 
-.poll-table.mobile td {
-  vertical-align: middle;
-  padding: 0;
-  border-width: 1px 0 0 !important;
+.poll-table.mobile {
+  overflow-x: hidden;
+
+  td {
+    vertical-align: middle;
+    padding: 0;
+    border-width: 1px 0 0 !important;
+  }
 }
 
 .btn.btn-transparent {

--- a/src/app/poll/mobile-poll-table.component.scss
+++ b/src/app/poll/mobile-poll-table.component.scss
@@ -7,7 +7,7 @@
 .poll-table.mobile td {
   vertical-align: middle;
   padding: 0;
-  border: unset;
+  border-width: 1px 0 0 !important;
 }
 
 .btn.btn-transparent {

--- a/src/app/poll/mobile-poll-table.component.scss
+++ b/src/app/poll/mobile-poll-table.component.scss
@@ -23,7 +23,12 @@
 }
 
 .poll-table td.suggested-date {
-  width: 150px;
+  @media (min-width: map-get($grid-breakpoints, sm)) {
+    width: 150px;
+  }
+  @media (min-width: map-get($grid-breakpoints, md)) {
+    width: 180px;
+  }
 }
 
 .toolbar {

--- a/src/app/poll/mobile-poll-table.component.scss
+++ b/src/app/poll/mobile-poll-table.component.scss
@@ -33,10 +33,13 @@
 
 .poll-table td.total-participants {
   padding: 0;
-  width: 60px;
 }
 
 .poll-table.mobile td.poll-options > img {
   margin-left: auto;
   margin-right: 1rem;
+}
+
+.voting-status-summary-image img {
+  display: block;
 }

--- a/src/app/poll/poll-form-helper.service.ts
+++ b/src/app/poll/poll-form-helper.service.ts
@@ -112,7 +112,7 @@ export class PollFormHelperService {
       case VotingStatusType.Declined:
         return this.translate.instant("votingStatus.declined");
       default:
-        return this.translate.instant("votingStatus.unknown");
+        return this.translate.instant("votingStatus.undefined");
     }
   }
 

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -339,6 +339,9 @@
                   >
                     <img alt="{{ 'poll.downloadCsv' | translate }}" aria-hidden="true" src="assets/calendar_grey.svg">
                   </button>
+                  <span class="font-small">
+                    {{ 'poll.downloadCsvDescription' | translate }}
+                  </span>
                 </td>
                 @for (date of model.suggestedDates; track date; let i = $index) {
                   <td class="suggested-date text-center font-weight-normal">

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -46,9 +46,10 @@
               <thead class="h-100" data-id="tableHead">
               <caption class="visually-hidden">{{ 'poll.caption' | translate }}</caption>
               <tr class="h-100">
-                <th></th>
+                <th scope="col"></th>
+                <th scope="col"><span class="sr-only">{{ 'poll.actions' | translate }}</span></th>
                 @for (date of model.suggestedDates; track date; let i = $index) {
-                  <th class="suggested-date text-center font-weight-normal">
+                  <th scope="col" class="suggested-date text-center font-weight-normal">
                     <div class="table-header-content">
                       <app-suggested-date [date]="date" id="suggested-date-{{i}}"></app-suggested-date>
                     </div>
@@ -65,6 +66,9 @@
                     <div class="col-7 ml-3 font-small text-bold participant-summary" data-id="participantSummary">
                       {{ formHelper.getNumberOfParticipants() }} {{ 'participant.participants' | translate }}
                     </div>
+                  </div>
+                </td>
+                <td>
                     <!-- button to add a participant -->
                     @if (!formHelper.hasAddOrEditParticipantForm() && !isAppointmentPaused) {
                       <div class="col-4">
@@ -82,7 +86,6 @@
                         </button>
                       </div>
                     }
-                  </div>
                 </td>
                 <!-- amount of confirmations per date -->
                 @for (date of model.suggestedDates; track date; let index = $index) {
@@ -91,7 +94,7 @@
                       class="row g-0 justify-content-center voting-status-summary-suggestion-date align-items-center"
                     >
                       <div class="d-inline-block voting-status-summary-image">
-                        <img alt="checkmark" aria-hidden="true" class="align-text-bottom"
+                        <img alt="" aria-hidden="true" class="align-text-bottom"
                              src="assets/status_accepted.svg">
                       </div>
                       <div class="font-weight-bold d-inline-block voting-status-summary-number"
@@ -107,7 +110,7 @@
                   <tr (keydown.enter)="$event.preventDefault()"
                       [formGroup]="formHelper.getParticipantForm()"
                       class="poll-add-user-row">
-                    <td class="p-2 poll-data-cell name">
+                    <th scope="row" class="p-2 poll-data-cell name">
                       <div class="row g-0 invalid-message-highlight" aria-live="assertive">
                         <!-- name -->
                         <div
@@ -126,18 +129,6 @@
                             type="text"
                             aria-describedby="no-name-add invalid-add-name too-long-add"
                           >
-                        </div>
-                        <!-- button to remove the form elements (so the participant won't be added) -->
-                        <div class="col-2 d-flex align-items-center justify-content-center">
-                          <button
-                            (click)="formHelper.deleteParticipantForm()"
-                            class="btn btn-transparent btn-trash w-100 h-100 ml-auto mr-0"
-                            data-id="deleteParticipantButton"
-                            id="delete-new-participant"
-                            type="button"
-                          >
-                            <img alt="trashcan" class="icon" src="assets/trash.svg"/>
-                          </button>
                         </div>
                         <div class="w-100"></div>
                         <!-- validation messages -->
@@ -175,6 +166,22 @@
                           }
                         </div>
                       </div>
+                    </th>
+                    <td class="h-100">
+                        <!-- button to remove the form elements (so the participant won't be added) -->
+                        <div class="d-flex h-100 align-items-center justify-content-center">
+                          <button
+                            (click)="formHelper.deleteParticipantForm()"
+                            class="btn btn-transparent btn-trash"
+                            data-id="deleteParticipantButton"
+                            id="delete-new-participant"
+                            title="{{ 'poll.deleteParticipant' | translate }}"
+                            type="button"
+                            aria-describedby="name-add"
+                          >
+                            <img alt="" aria-hidden="true" class="icon" src="assets/trash.svg"/>
+                          </button>
+                        </div>
                     </td>
                     <!-- the new participant's poll options -->
                     @if (formHelper.getParticipantFormVotings()) {
@@ -202,9 +209,12 @@
                         <div class="participant-container">
                           <!-- name -->
                           <span class="text-bold">{{ participant.name }}</span>
+                        </div>
+                      </th>
+                      <td class="h-100">
                           <!-- button to edit the participant -->
                           @if (!formHelper.hasAddParticipantForm() && !formHelper.hasEditParticipantForm() && !isAppointmentPaused) {
-                            <span class="float-end">
+                            <div class="d-flex h-100 align-items-center justify-content-center">
                               <button
                                 (click)="formHelper.editParticipant(participant)"
                                 class="btn btn-transparent p-0 border-0"
@@ -212,12 +222,11 @@
                                 type="button"
                                 title="{{ 'poll.editParticipant' | translate}}"
                               >
-                                <img aria-hidden="true" alt="pencil" class="icon icon-edit" src="assets/edit.svg"/>
+                                <img aria-hidden="true" alt="" class="icon icon-edit" src="assets/edit.svg"/>
                               </button>
-                            </span>
+                            </div>
                           }
-                        </div>
-                      </th>
+                      </td>
                       @for (date of model.suggestedDates; track date) {
                         <td class="td-full-height">
                           <div class="h-100 d-flex align-items-center">
@@ -261,18 +270,6 @@
                               aria-describedby="no-name-edit invalid-edit-name too-long-edit"
                             >
                           </div>
-                          <!-- button to delete the currently edited participant -->
-                          <div class="col-2 d-flex align-items-center justify-content-center">
-                            <button
-                              (click)="formHelper.deleteEditParticipant(participant)"
-                              class="btn btn-transparent btn-trash w-100 h-100 ml-auto mr-0"
-                              data-id="deleteEditedParticipantButton"
-                              id="delete-edit-participant"
-                              type="button"
-                            >
-                              <img alt="trashcan" class="icon" src="assets/trash.svg"/>
-                            </button>
-                          </div>
                           <div class="w-100"></div>
                           <!-- validation messages -->
                           <div class="col-auto">
@@ -302,6 +299,22 @@
                             }
                           </div>
                         </div>
+                      </td>
+                      <td class="h-100">
+                          <!-- button to delete the currently edited participant -->
+                          <div class="d-flex h-100 align-items-center justify-content-center">
+                            <button
+                              (click)="formHelper.deleteEditParticipant(participant)"
+                              class="btn btn-transparent btn-trash"
+                              data-id="deleteEditedParticipantButton"
+                              id="delete-edit-participant"
+                              type="button"
+                              aria-describedby="name-edit"
+                              title="{{ 'poll.deleteParticipant' | translate }}"
+                            >
+                              <img alt="" aria-hidden="true" class="icon" src="assets/trash.svg"/>
+                            </button>
+                          </div>
                       </td>
                       <!-- poll options per date -->
                       @for (date of model.suggestedDates; track date) {
@@ -339,7 +352,7 @@
                     title="{{ 'poll.downloadCsv' | translate }}"
                     type="button"
                   >
-                    <img alt="{{ 'poll.downloadCsv' | translate }}" aria-hidden="true" src="assets/calendar_grey.svg">
+                    <img alt="" aria-hidden="true" src="assets/calendar_grey.svg">
                   </button>
                   <span class="font-small">
                     {{ 'poll.downloadCsvDescription' | translate }}
@@ -356,7 +369,7 @@
                       title="{{ 'poll.downloadIcs' | translate }}"
                       type="button"
                     >
-                      <img alt="{{ 'poll.downloadIcs' | translate }}" aria-hidden="true" src="assets/download.svg">
+                      <img alt="" aria-hidden="true" src="assets/download.svg">
                     </button>
                   </td>
                 }

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -51,7 +51,7 @@
                 @for (date of model.suggestedDates; track date; let i = $index) {
                   <th scope="col" class="suggested-date text-center font-weight-normal">
                     <div class="table-header-content">
-                      <app-suggested-date [date]="date" id="suggested-date-{{i}}"></app-suggested-date>
+                      <app-suggested-date [date]="date" id="suggested-date-{{i}}" [index]="i"></app-suggested-date>
                     </div>
                   </th>
                 }

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -69,23 +69,21 @@
                   </div>
                 </td>
                 <td>
-                    <!-- button to add a participant -->
-                    @if (!formHelper.hasAddOrEditParticipantForm() && !isAppointmentPaused) {
-                      <div class="col-4">
-                        <button
-                          (click)="formHelper.addParticipant()"
-                          class="btn btn-round btn-secondary btn-add-participant float-end"
-                          data-id="addParticipantButton"
-                          data-placement="top"
-                          data-toggle="tooltip"
-                          id="add-participant"
-                          title="{{ 'poll.addParticipant' | translate }}"
-                          type="button"
-                        >
-                          <img alt="" aria-hidden="true" class="add-participant-icon" src="assets/add-user.svg">
-                        </button>
-                      </div>
-                    }
+                  <!-- button to add a participant -->
+                  @if (!formHelper.hasAddOrEditParticipantForm() && !isAppointmentPaused) {
+                    <button
+                      (click)="formHelper.addParticipant()"
+                      class="btn btn-round btn-secondary btn-add-participant float-end"
+                      data-id="addParticipantButton"
+                      data-placement="top"
+                      data-toggle="tooltip"
+                      id="add-participant"
+                      title="{{ 'poll.addParticipant' | translate }}"
+                      type="button"
+                    >
+                      <img alt="" aria-hidden="true" class="add-participant-icon" src="assets/add-user.svg">
+                    </button>
+                  }
                 </td>
                 <!-- amount of confirmations per date -->
                 @for (date of model.suggestedDates; track date; let index = $index) {

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -358,6 +358,7 @@
                     {{ 'poll.downloadCsvDescription' | translate }}
                   </span>
                 </td>
+                <td></td>
                 @for (date of model.suggestedDates; track date; let i = $index) {
                   <td class="suggested-date text-center font-weight-normal">
                     <button

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -209,7 +209,7 @@
                           <span class="text-bold">{{ participant.name }}</span>
                         </div>
                       </th>
-                      <td class="h-100">
+                      <td class="td-full-height">
                           <!-- button to edit the participant -->
                           @if (!formHelper.hasAddParticipantForm() && !formHelper.hasEditParticipantForm() && !isAppointmentPaused) {
                             <div class="d-flex h-100 align-items-center justify-content-center">

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -197,7 +197,7 @@
                   <tr [ngClass]="{'poll-edit-user-row': formHelper.isEditInParticipantForm(participant.participantId)}">
                     <!-- if the current row is not being edited just display the name & votes of the participant -->
                     @if (!formHelper.isEditInParticipantForm(participant.participantId)) {
-                      <td class="pl-3">
+                      <th class="pl-3" scope="row">
                         <div class="participant-container">
                           <!-- name -->
                           <span class="text-bold">{{ participant.name }}</span>
@@ -218,7 +218,7 @@
                             </span>
                           }
                         </div>
-                      </td>
+                      </th>
                       @for (date of model.suggestedDates; track date) {
                         <td class="td-full-height">
                           <div class="h-100 d-flex align-items-center">

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -44,11 +44,11 @@
             <table class="table table-striped table-hover mb-0 bordered poll-table d-none d-lg-block">
               <!-- first row contains the suggested dates -->
               <thead class="h-100" data-id="tableHead">
+              <caption class="visually-hidden">{{ 'poll.caption' | translate }}</caption>
               <tr class="h-100">
                 <th></th>
                 @for (date of model.suggestedDates; track date; let i = $index) {
-                  <th
-                    class="suggested-date text-center font-weight-normal">
+                  <th class="suggested-date text-center font-weight-normal">
                     <div class="table-header-content">
                       <app-suggested-date [date]="date" id="suggested-date-{{i}}"></app-suggested-date>
                     </div>

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -88,7 +88,8 @@
                 @for (date of model.suggestedDates; track date; let index = $index) {
                   <td class="text-center poll-summary-data-cell">
                     <div
-                      class="row g-0 justify-content-center voting-status-summary-suggestion-date align-items-center">
+                      class="row g-0 justify-content-center voting-status-summary-suggestion-date align-items-center"
+                    >
                       <div class="d-inline-block voting-status-summary-image">
                         <img alt="checkmark" aria-hidden="true" class="align-text-bottom"
                              src="assets/status_accepted.svg">
@@ -203,9 +204,7 @@
                           <span class="text-bold">{{ participant.name }}</span>
                           <!-- button to edit the participant -->
                           @if (!formHelper.hasAddParticipantForm() && !formHelper.hasEditParticipantForm() && !isAppointmentPaused) {
-                            <span
-                              class="float-end"
-                            >
+                            <span class="float-end">
                               <button
                                 (click)="formHelper.editParticipant(participant)"
                                 class="btn btn-transparent p-0 border-0"
@@ -238,9 +237,12 @@
                         <div class="row g-0 invalid-message-highlight" aria-live="assertive">
                           <!-- name input -->
                           <div
-                            [ngClass]="{'has-error': formHelper.getParticipantFormName().invalid  &&
-                    (formHelper.getParticipantFormName().dirty || formHelper.getParticipantFormName().touched)}"
-                            class="col-10 form-group">
+                            [ngClass]="{
+                             'has-error': formHelper.getParticipantFormName().invalid
+                               && (formHelper.getParticipantFormName().dirty || formHelper.getParticipantFormName().touched)
+                             }"
+                            class="col-10 form-group"
+                          >
                             <label
                               class="sr-only"
                               data-id="nameEditLabel"

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -237,8 +237,9 @@
                                 class="btn btn-transparent p-0 border-0"
                                 id="editButton-{{index}}"
                                 type="button"
+                                title="{{ 'poll.editParticipant' | translate}}"
                               >
-                                <img alt="pencil" class="icon icon-edit" src="assets/edit.svg"/>
+                                <img aria-hidden="true" alt="pencil" class="icon icon-edit" src="assets/edit.svg"/>
                               </button>
                             </span>
                           }

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -45,37 +45,12 @@
               <!-- first row contains the suggested dates -->
               <thead class="h-100" data-id="tableHead">
               <tr class="h-100">
-                <th>
-                  <button
-                    (click)="formHelper.downloadCsv()"
-                    class="download-csv btn btn-rounded btn-sm btn-light"
-                    data-id="downloadCsvButton"
-                    data-placement="top"
-                    data-toggle="tooltip"
-                    id="download-csv"
-                    title="{{ 'poll.downloadCsv' | translate }}"
-                    type="button"
-                  >
-                    <img alt="{{ 'poll.downloadCsv' | translate }}" aria-hidden="true" src="assets/calendar_grey.svg">
-                  </button>
-                </th>
+                <th></th>
                 @for (date of model.suggestedDates; track date; let i = $index) {
                   <th
                     class="suggested-date text-center font-weight-normal">
                     <div class="table-header-content">
                       <app-suggested-date [date]="date" id="suggested-date-{{i}}"></app-suggested-date>
-                      <div class="spacer"></div>
-                      <button
-                        (click)="formHelper.downloadCal(date, i)"
-                        class="download-cal btn btn-rounded btn-sm btn-light"
-                        data-placement="top"
-                        data-toggle="tooltip"
-                        id="download-cal-{{i}}"
-                        title="{{ 'poll.downloadIcs' | translate }}"
-                        type="button"
-                      >
-                        <img alt="{{ 'poll.downloadIcs' | translate }}" aria-hidden="true" src="assets/download.svg">
-                      </button>
                     </div>
                   </th>
                 }
@@ -219,8 +194,7 @@
                 }
               <!-- display the votings of all participants -->
                 @for (participant of model.participants; track participant; let index = $index) {
-                  <tr
-                    [ngClass]="{'poll-edit-user-row': formHelper.isEditInParticipantForm(participant.participantId)}">
+                  <tr [ngClass]="{'poll-edit-user-row': formHelper.isEditInParticipantForm(participant.participantId)}">
                     <!-- if the current row is not being edited just display the name & votes of the participant -->
                     @if (!formHelper.isEditInParticipantForm(participant.participantId)) {
                       <td class="pl-3">
@@ -352,6 +326,39 @@
                   </tr>
                 }
               </tbody>
+              <tfoot>
+              <tr class="h-100">
+                <td>
+                  <button
+                    (click)="formHelper.downloadCsv()"
+                    class="download-csv btn btn-rounded btn-sm btn-light"
+                    data-id="downloadCsvButton"
+                    data-placement="top"
+                    data-toggle="tooltip"
+                    id="download-csv"
+                    title="{{ 'poll.downloadCsv' | translate }}"
+                    type="button"
+                  >
+                    <img alt="{{ 'poll.downloadCsv' | translate }}" aria-hidden="true" src="assets/calendar_grey.svg">
+                  </button>
+                </td>
+                @for (date of model.suggestedDates; track date; let i = $index) {
+                  <td class="suggested-date text-center font-weight-normal">
+                    <button
+                      (click)="formHelper.downloadCal(date, i)"
+                      class="download-cal btn btn-rounded btn-sm btn-light"
+                      data-placement="top"
+                      data-toggle="tooltip"
+                      id="download-cal-{{i}}"
+                      title="{{ 'poll.downloadIcs' | translate }}"
+                      type="button"
+                    >
+                      <img alt="{{ 'poll.downloadIcs' | translate }}" aria-hidden="true" src="assets/download.svg">
+                    </button>
+                  </td>
+                }
+              </tr>
+              </tfoot>
             </table>
           </div>
         }

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -224,11 +224,9 @@
                           <div class="h-100 d-flex align-items-center">
                             <!--suppress HtmlUnknownTarget no inspection for this dynamic src path -->
                             <img
-                              alt="voting-status"
-                              aria-hidden="true"
-                              class="mx-auto d-block poll-option-icon" src="assets/status_{{
-                    formHelper.getVotingStatusBySuggestedDateIdAndParticipantId(date.suggestedDateId, participant.participantId)
-                    }}.svg">
+                              alt="{{ 'votingStatus.' + formHelper.getVotingStatusBySuggestedDateIdAndParticipantId(date.suggestedDateId, participant.participantId) | translate}}"
+                              class="mx-auto d-block poll-option-icon"
+                              src="assets/status_{{formHelper.getVotingStatusBySuggestedDateIdAndParticipantId(date.suggestedDateId, participant.participantId)}}.svg">
                           </div>
                         </td>
                       }

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -49,7 +49,7 @@ tbody tr:last-child td {
     position: sticky;
     background: white;
     z-index: 1;
-    top: 135.4px; // smallest height of thead | dynamic value | different across browser-engines (+- .3px)
+    top: 116.4px; // smallest height of thead | dynamic value | different across browser-engines (+- .3px)
   }
 
   tbody tr > td:first-child:not(.poll-summary-row) {

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -25,7 +25,7 @@ thead tr:first-child th {
   border-top: 0 !important;
 }
 
-tbody tr:last-child td {
+tfoot tr:last-child td {
   border-bottom: 0 !important;
 }
 

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -240,13 +240,9 @@ button.btn-with-image {
   margin-bottom: 0;
 }
 
-.voting-status-summary-image {
-  margin-right: 4px;
-
-  img {
-    width: $poll-option-width-small;
-    height: $poll-option-width-small;
-  }
+.voting-status-summary-image img {
+  width: $poll-option-width-small;
+  height: $poll-option-width-small;
 }
 
 .poll-summary-row {

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -38,6 +38,7 @@ tbody tr:last-child td {
 
 // sticky header and first column
 @media (min-width: map-get($grid-breakpoints, lg)) {
+  // suggested dates
   thead tr {
     position: sticky;
     background: white;
@@ -45,25 +46,50 @@ tbody tr:last-child td {
     top: 0;
   }
 
+  // top left table item
+  thead th:first-child {
+    position: sticky;
+    background: white;
+    z-index: 1;
+    top: 0;
+    left: 0;
+  }
+
+  // poll summary row
   tbody tr:first-child {
     position: sticky;
     background: white;
     z-index: 1;
-    top: 116.4px; // smallest height of thead | dynamic value | different across browser-engines (+- .3px)
+    top: 92.7px; // smallest height of thead | dynamic value | different across browser-engines (+- .3px)
+
+    td:first-child {
+      position: sticky;
+      left: 0;
+    }
   }
 
-  tbody tr > td:first-child:not(.poll-summary-row) {
+  // add/edit participant
+  tr.poll-add-user-row,
+  tr.poll-edit-user-row {
+    td:first-child {
+      position: sticky;
+      left: 0;
+    }
+  }
+
+  // name of participants
+  tbody th {
     position: sticky;
     background: white;
     z-index: 0;
     left: 0;
   }
 
-  thead th:first-child {
+  // download buttons
+  tfoot td:first-child {
     position: sticky;
     background: white;
-    z-index: 1;
-    top: 0;
+    z-index: 0;
     left: 0;
   }
 }

--- a/src/app/poll/poll.component.ts
+++ b/src/app/poll/poll.component.ts
@@ -29,10 +29,8 @@ export class PollComponent implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
-    private router: Router,
     private logger: Logger,
     private dataRepoService: DataRepositoryService,
-    private modelTransformer: ModelTransformerService,
     private appStateService: AppStateService,
     public formHelper: PollFormHelperService
   ) {

--- a/src/app/shared/components/dates-overview/dates-overview.component.html
+++ b/src/app/shared/components/dates-overview/dates-overview.component.html
@@ -2,10 +2,10 @@
   <div class="date-time-overview">
     <table class="table mobile d-table d-lg-none w-100" data-id="overviewDatesMobile">
       <tbody>
-        @for (date of appointment.suggestedDates; track date) {
+        @for (date of appointment.suggestedDates; track date; let i = $index) {
           <tr>
             <td>
-              <app-suggested-date [date]="date"></app-suggested-date>
+              <app-suggested-date [date]="date" [index]="i"></app-suggested-date>
             </td>
           </tr>
         }
@@ -15,9 +15,9 @@
       <table class="table table-borderless desktop d-inline-block mt-3 mb-1" data-id="overviewDatesDesktop">
         <tbody>
         <tr>
-          @for (date of appointment.suggestedDates; track date) {
+          @for (date of appointment.suggestedDates; track date; let i = $index) {
             <td>
-              <app-suggested-date [date]="date"></app-suggested-date>
+              <app-suggested-date [date]="date" [index]="i"></app-suggested-date>
             </td>
           }
         </tr>

--- a/src/app/shared/components/poll-options/poll-options.component.html
+++ b/src/app/shared/components/poll-options/poll-options.component.html
@@ -1,94 +1,66 @@
 @if (formGroup !== null) {
-  <div
-    [formGroup]="formGroup"
-    class="row g-0 justify-content-end justify-content-lg-around align-items-center align-self-center max-content"
-  >
+  <div class="row">
+    <div class="col d-flex justify-content-center">
+      <img
+        alt=""
+        aria-hidden="true"
+        class="poll-option-icon"
+        src="assets/status_declined.svg"
+      >
+    </div>
+    <div class="col d-flex justify-content-center">
+      <img
+        alt=""
+        aria-hidden="true"
+        class="poll-option-icon"
+        src="assets/status_questionable.svg"
+      >
+    </div>
+    <div class="col d-flex justify-content-center">
+      <img
+        alt=""
+        aria-hidden="true"
+        class="poll-option-icon"
+        src="assets/status_accepted.svg"
+      >
+    </div>
+  </div>
+  <div [formGroup]="formGroup" class="row mt-1">
     <div class="col">
-      <div class="row g-0 justify-content-center">
-        <div class="col-auto">
-          <label
-            class="form-check-label"
-            for="{{getPrefix()}}-voting-status-declined-{{selectorId}}"
-          >
-            <span class="sr-only">{{ 'date.date' | translate }} {{ 'votingStatus.declined' | translate }}</span>
-            <img
-              alt="hidden"
-              aria-hidden="true"
-              class="poll-option-icon"
-              id="{{getPrefix()}}-label-status-declined-{{selectorId}}"
-              src="assets/status_declined.svg"
-            >
-          </label>
-        </div>
-        <div class="w-100"></div>
-        <div class="col-auto">
-          <input
-            required
-            class="status-declined"
-            formControlName="status"
-            id="{{getPrefix()}}-voting-status-declined-{{selectorId}}"
-            type="radio"
-            value="declined"
-          >
-        </div>
+      <div class="d-flex justify-content-center">
+        <input
+          class=""
+          id="{{getPrefix()}}-label-status-declined-{{selectorId}}"
+          formControlName="status"
+          type="radio"
+          value="declined"
+          [attr.aria-label]="'votingStatus.declined' | translate"
+        >
       </div>
     </div>
     <div class="col">
-      <div class="row g-0 justify-content-center">
-        <div class="col-auto">
-          <label
-            class="w-100 form-check-label"
-            for="{{getPrefix()}}-voting-status-questionable-{{selectorId}}"
-          >
-            <span class="sr-only">{{ 'date.date' | translate }} {{ 'votingStatus.questionable' | translate }}</span>
-            <img
-              alt="hidden"
-              aria-hidden="true"
-              class="poll-option-icon"
-              id="{{getPrefix()}}-label-status-questionable-{{selectorId}}"
-              src="assets/status_questionable.svg"
-            >
-          </label>
-        </div>
-        <div class="w-100"></div>
-        <div class="col-auto">
-          <input
-            class="status-questionable"
-            formControlName="status"
-            id="{{getPrefix()}}-voting-status-questionable-{{selectorId}}"
-            type="radio"
-            value="questionable"
-          >
-        </div>
+      <div class="d-flex justify-content-center">
+        <input
+          class=""
+          type="radio"
+          id="{{getPrefix()}}-label-status-questionable-{{selectorId}}"
+          formControlName="status"
+          value="questionable"
+          [attr.aria-label]="'votingStatus.questionable' | translate"
+          checked
+        >
       </div>
     </div>
     <div class="col">
-      <div class="row g-0 justify-content-center">
-        <div class="col-auto">
-          <label
-            class="form-check-label"
-            for="{{getPrefix()}}-voting-status-accepted-{{selectorId}}"
-          >
-            <span class="sr-only">{{ 'date.date' | translate }} {{ 'votingStatus.accepted' | translate }}</span>
-            <img
-              alt="hidden"
-              aria-hidden="true"
-              class="poll-option-icon"
-              id="{{getPrefix()}}-label-status-accepted-{{selectorId}}"
-              src="assets/status_accepted.svg"
-            >
-          </label>
-        </div>
-        <div class="w-100"></div>
-        <div class="col-auto">
-          <input
-            class="status-accepted"
-            formControlName="status"
-            id="{{getPrefix()}}-voting-status-accepted-{{selectorId}}"
-            type="radio"
-            value="accepted"
-          >
-        </div>
+      <div class="d-flex justify-content-center">
+        <input
+          class=""
+          type="radio"
+          id="{{getPrefix()}}-label-status-accepted-{{selectorId}}"
+          formControlName="status"
+          value="accepted"
+          [attr.aria-label]="'votingStatus.accepted' | translate"
+        >
       </div>
     </div>
   </div>

--- a/src/app/shared/components/poll-options/poll-options.component.html
+++ b/src/app/shared/components/poll-options/poll-options.component.html
@@ -30,7 +30,7 @@
       <div class="d-flex justify-content-center">
         <input
           class=""
-          id="{{getPrefix()}}-label-status-declined-{{selectorId}}"
+          id="{{getPrefix()}}-voting-status-declined-{{selectorId}}"
           formControlName="status"
           type="radio"
           value="declined"
@@ -43,7 +43,7 @@
         <input
           class=""
           type="radio"
-          id="{{getPrefix()}}-label-status-questionable-{{selectorId}}"
+          id="{{getPrefix()}}-voting-status-questionable-{{selectorId}}"
           formControlName="status"
           value="questionable"
           [attr.aria-label]="'votingStatus.questionable' | translate"
@@ -56,7 +56,7 @@
         <input
           class=""
           type="radio"
-          id="{{getPrefix()}}-label-status-accepted-{{selectorId}}"
+          id="{{getPrefix()}}-voting-status-accepted-{{selectorId}}"
           formControlName="status"
           value="accepted"
           [attr.aria-label]="'votingStatus.accepted' | translate"

--- a/src/app/shared/components/poll-options/poll-options.component.scss
+++ b/src/app/shared/components/poll-options/poll-options.component.scss
@@ -1,18 +1,6 @@
 @import "src/default";
 
-.form-check-label {
-  margin: 0;
-
-  img {
-    width: $poll-option-width-small;
-    height: $poll-option-width-small;
-  }
-}
-
-.max-content {
-  min-width: max-content;
-}
-
-.min-content {
-  max-width: min-content;
+img.poll-option-icon {
+  width: $poll-option-width-small;
+  height: $poll-option-width-small;
 }

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -33,11 +33,9 @@
     <div class="day">{{ date.startDate | date:'dd': '': getLocale() }}</div>
     <div>{{ date.startDate | date:'E': '': getLocale() | slice: 0:2 }}</div>
     <!-- display start time here if:
-      - there's an end date OR
-      - on a desktop (lg+) device -->
-    <div [ngClass]="{'d-none': !date.endDate}"
-         class="d-lg-block">{{ date.startTime | date:'HH:mm': '': getLocale() }}
-    </div>
+    - on a desktop (lg+) device OR
+    - if there's no end date  -->
+    <div [ngClass]="{'d-none d-lg-block': !date.endDate}">{{ date.startTime | date:'HH:mm': '': getLocale() }}</div>
     <!-- display hyphen and endTime if:
     - on a desktop (lg+) device AND
     - if there's no end date  -->

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -52,7 +52,7 @@
     <div class="col-auto align-self-center d-lg-none" aria-hidden="true">
       <div class="ms-1 me-2 date-time-divider"></div>
     </div>
-    <div class="col d-flex d-lg-none column" aria-hidden="true">
+    <div class="col d-flex d-lg-none column position-relative" aria-hidden="true">
       <div class="row g-0 align-self-center w-100">
         <div class="col">
           <div>{{ date.startTime | date:'HH:mm': '': getLocale() }}</div>

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -1,8 +1,8 @@
 <div
   class="row g-0 justify-content-center text-center suggested-date-container"
-  [attr.aria-labelledby]="'full-date-' + date.suggestedDateId"
+  [attr.aria-labelledby]="'full-date-' + index"
 >
-  <span id="full-date-{{ date.suggestedDateId }}" class="visually-hidden">
+  <span id="full-date-{{ index }}" class="visually-hidden">
     @if (!date.endDate && !date.endTime) {
       {{ date.startDate | date:'EEEE dd. MMMM YYYY': '': getLocale() }}
     } @else if (date.startTime && !date.endDate && date.endTime) {

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -27,7 +27,7 @@
     }
   </span>
   <!-- column on the left or centered with start date and - for desktop resolutions - start and end time  -->
-  <div class="col-5 column position-relative" aria-hidden="true">
+  <div class="col-5 column" aria-hidden="true">
     <!-- start date -->
     <div>{{ date.startDate | date:'MMM': '': getLocale() | slice: 0:3 }}</div>
     <div class="day">{{ date.startDate | date:'dd': '': getLocale() }}</div>
@@ -39,10 +39,7 @@
     <!-- display hyphen and endTime if:
     - on a desktop (lg+) device AND
     - if there's no end date  -->
-    <div [ngClass]="{'d-lg-block': date.endTime && !date.endDate}"
-         class="position-absolute d-none hyphen start-0 end-0">
-      -
-    </div>
+    <div [ngClass]="{'d-lg-block': date.endTime && !date.endDate}" class="d-none hyphen"></div>
     <div [ngClass]="{'d-lg-block': date.endTime && !date.endDate}"
          class="d-none">{{ date.endTime | date:'HH:mm': '': getLocale() }}
     </div>
@@ -52,25 +49,23 @@
     <div class="col-auto align-self-center d-lg-none" aria-hidden="true">
       <div class="ms-1 me-2 date-time-divider"></div>
     </div>
-    <div class="col d-flex d-lg-none column position-relative" aria-hidden="true">
-      <div class="row g-0 align-self-center w-100">
+    <div class="col d-flex d-lg-none column align-items-center" aria-hidden="true">
+      <div class="row g-0 w-100 d-block">
         <div class="col">
           <div>{{ date.startTime | date:'HH:mm': '': getLocale() }}</div>
         </div>
         @if (date.endTime) {
-          <div class="col">
-            <div>{{ date.endTime | date:'HH:mm': '': getLocale() }}</div>
-          </div>
-          <div class="position-absolute d-lg-none hyphen start-0 end-0">
-            -
-          </div>
+          <div class="d-lg-none hyphen"></div>
         }
+        <div class="col">
+          <div>{{ date.endTime | date:'HH:mm': '': getLocale() }}</div>
+        </div>
       </div>
     </div>
   }
   <!-- column on the right for end date and end time -->
   @if (date.endDate) {
-    <div class="col-1 align-self-center hyphen" aria-hidden="true">
+    <div class="col-1 align-self-center font-medium" aria-hidden="true">
       -
     </div>
     <div class="col-5 column" aria-hidden="true">

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -5,6 +5,7 @@
   <span id="full-date-{{ index }}" class="visually-hidden">
     @if (!date.endDate && !date.endTime) {
       {{ date.startDate | date:'EEEE dd. MMMM YYYY': '': getLocale() }}
+      {{ date.startTime | date:'HH:mm': '': getLocale() }}
     } @else if (date.startTime && !date.endDate && date.endTime) {
       {{ date.startDate | date:'EEEE dd. MMMM YYYY': '': getLocale() }}
       {{ 'date.from' | translate }}

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -1,6 +1,29 @@
-<div class="row g-0 mb-1 justify-content-center text-center suggested-date-container">
+<div class="row g-0 justify-content-center text-center suggested-date-container" aria-labelledby="full-date">
+  <span id="full-date" class="visually-hidden">
+    @if (!date.endDate && !date.endTime) {
+      {{ date.startDate | date:'EEEE dd. MMMM YYYY': '': getLocale() }}
+    } @else if (date.startTime && !date.endDate && date.endTime) {
+      {{ date.startDate | date:'EEEE dd. MMMM YYYY': '': getLocale() }}
+      {{ 'date.from' | translate }}
+      {{ date.startTime | date:'HH:mm': '': getLocale() }}
+      {{ 'date.to' | translate }}
+      {{ date.endTime | date:'HH:mm': '': getLocale() }}
+    } @else if (!date.startTime && date.endDate && !date.endTime) {
+      {{ 'date.from' | translate }}
+      {{ date.startDate | date:'EEEE dd. MMMM YYYY': '': getLocale() }}
+      {{ 'date.to' | translate }}
+      {{ date.endDate | date:'EEEE, dd. MMMM YYYY': '': getLocale() }}
+    } @else {
+      {{ 'date.from' | translate }}
+      {{ date.startDate | date:'EEEE dd. MMMM YYYY': '': getLocale() }}
+      {{ date.startTime | date:'HH:mm': '': getLocale() }}
+      {{ 'date.to' | translate }}
+      {{ date.endDate | date:'EEEE, dd. MMMM YYYY': '': getLocale() }}
+      {{ date.endTime | date:'HH:mm': '': getLocale() }}
+    }
+  </span>
   <!-- column on the left or centered with start date and - for desktop resolutions - start and end time  -->
-  <div class="col-5 column position-relative">
+  <div class="col-5 column" aria-hidden="true">
     <!-- start date -->
     <div>{{ date.startDate | date:'MMM': '': getLocale() | slice: 0:3 }}</div>
     <div class="day">{{ date.startDate | date:'dd': '': getLocale() }}</div>
@@ -24,10 +47,10 @@
   </div>
   <!-- column on the right for start and end time - only on mobile resolutions -->
   @if (date.startTime && !date.endDate) {
-    <div class="col-auto align-self-center d-lg-none">
+    <div class="col-auto align-self-center d-lg-none" aria-hidden="true">
       <div class="ml-1 mr-2 d-inline-block date-time-divider"></div>
     </div>
-    <div class="col d-flex d-lg-none column position-relative">
+    <div class="col d-flex d-lg-none column" aria-hidden="true">
       <div class="row g-0 align-self-center w-100">
         <div class="col">
           <div>{{ date.startTime | date:'HH:mm': '': getLocale() }}</div>
@@ -45,10 +68,10 @@
   }
   <!-- column on the right for end date and end time -->
   @if (date.endDate) {
-    <div class="col-1 align-self-center hyphen">
+    <div class="col-1 align-self-center hyphen" aria-hidden="true">
       -
     </div>
-    <div class="col-5 column">
+    <div class="col-5 column" aria-hidden="true">
       <div>{{ date.endDate | date:'MMM': '': getLocale() | slice: 0:3 }}</div>
       <div class="day">{{ date.endDate | date:'dd': '': getLocale() }}</div>
       <div>{{ date.endDate | date:'E': '': getLocale() | slice: 0:2 }}</div>

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -27,7 +27,7 @@
     }
   </span>
   <!-- column on the left or centered with start date and - for desktop resolutions - start and end time  -->
-  <div class="col-5 column" aria-hidden="true">
+  <div class="col-5 column position-relative" aria-hidden="true">
     <!-- start date -->
     <div>{{ date.startDate | date:'MMM': '': getLocale() | slice: 0:3 }}</div>
     <div class="day">{{ date.startDate | date:'dd': '': getLocale() }}</div>

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -1,5 +1,8 @@
-<div class="row g-0 justify-content-center text-center suggested-date-container" aria-labelledby="full-date">
-  <span id="full-date" class="visually-hidden">
+<div
+  class="row g-0 justify-content-center text-center suggested-date-container"
+  [attr.aria-labelledby]="'full-date-' + date.suggestedDateId"
+>
+  <span id="full-date-{{ date.suggestedDateId }}" class="visually-hidden">
     @if (!date.endDate && !date.endTime) {
       {{ date.startDate | date:'EEEE dd. MMMM YYYY': '': getLocale() }}
     } @else if (date.startTime && !date.endDate && date.endTime) {

--- a/src/app/shared/components/suggested-date/suggested-date.component.html
+++ b/src/app/shared/components/suggested-date/suggested-date.component.html
@@ -52,7 +52,7 @@
   <!-- column on the right for start and end time - only on mobile resolutions -->
   @if (date.startTime && !date.endDate) {
     <div class="col-auto align-self-center d-lg-none" aria-hidden="true">
-      <div class="ml-1 mr-2 d-inline-block date-time-divider"></div>
+      <div class="ms-1 me-2 date-time-divider"></div>
     </div>
     <div class="col d-flex d-lg-none column" aria-hidden="true">
       <div class="row g-0 align-self-center w-100">

--- a/src/app/shared/components/suggested-date/suggested-date.component.scss
+++ b/src/app/shared/components/suggested-date/suggested-date.component.scss
@@ -21,17 +21,10 @@ div {
 }
 
 .hyphen {
-  font-size: 25px;
-
-  // desktop
-  &.position-absolute.d-lg-block {
-    bottom: 0.375rem;
-  }
-
-  // mobile
-  &.position-absolute.d-lg-none {
-    bottom: 1rem;
-  }
+  width: 7px;
+  height: 1.3px;
+  margin: auto;
+  background: black;
 }
 
 .suggested-date-container .column {

--- a/src/app/shared/components/suggested-date/suggested-date.component.scss
+++ b/src/app/shared/components/suggested-date/suggested-date.component.scss
@@ -21,7 +21,7 @@ div {
 }
 
 .hyphen {
-  width: 7px;
+  width: 6px;
   height: 1.3px;
   margin: auto;
   background: black;

--- a/src/app/shared/components/suggested-date/suggested-date.component.ts
+++ b/src/app/shared/components/suggested-date/suggested-date.component.ts
@@ -9,6 +9,7 @@ import {LocaleService} from '../../services/locale/locale.service';
 })
 export class SuggestedDateComponent {
   @Input() date: SuggestedDate;
+  @Input() index: number;
 
   constructor(private localeService: LocaleService) {
   }

--- a/src/app/shared/components/suggested-date/suggested-date.component.ts
+++ b/src/app/shared/components/suggested-date/suggested-date.component.ts
@@ -16,5 +16,4 @@ export class SuggestedDateComponent {
   getLocale(): string {
     return this.localeService.getLocale().languageCode;
   }
-
 }

--- a/src/locales/de-DE-du.json
+++ b/src/locales/de-DE-du.json
@@ -95,6 +95,7 @@
     "accepted": "zugesagt",
     "questionable": "vorbehaltlich",
     "declined": "abgelehnt",
+    "undefined": "unbekannt",
     "unknown": "unbekannt"
   },
   "date": {

--- a/src/locales/de-DE-du.json
+++ b/src/locales/de-DE-du.json
@@ -49,6 +49,7 @@
     "editSaveLastStep": "In Schritt \"4\" kannst Du alle Änderungen speichern.",
     "answer": "Beantworte die Umfrage von",
     "addParticipant": "Teilnehmende hinzufügen",
+    "editParticipant": "Teilnehmende hinzufügen",
     "noParticipation": "Ich kann nicht teilnehmen",
     "send": "Abschicken",
     "downloadIcs": "Lade dieses Datum als .ics-Datei herunter und importiere es in deinen Kalender. Erfahre in der Beschreibung des Termins, wie die Teilnehmenden abgestimmt haben.",

--- a/src/locales/de-DE-du.json
+++ b/src/locales/de-DE-du.json
@@ -54,6 +54,7 @@
     "send": "Abschicken",
     "downloadIcs": "Lade dieses Datum als .ics-Datei herunter und importiere es in deinen Kalender. Erfahre in der Beschreibung des Termins, wie die Teilnehmenden abgestimmt haben.",
     "downloadCsv": "Lade die Tabelle der Teilnehmenden mit ihren Entscheidungen herunter. Du kannst sie in Excel importieren, um deine Veranstaltung besser zu planen.",
+    "downloadCsvDescription": "Tabelle als csv Datei herunterladen",
     "title": {
       "title": "Titel",
       "set": "Gib Deiner Umfrage einen Titel!",

--- a/src/locales/de-DE-du.json
+++ b/src/locales/de-DE-du.json
@@ -55,6 +55,7 @@
     "downloadIcs": "Lade dieses Datum als .ics-Datei herunter und importiere es in deinen Kalender. Erfahre in der Beschreibung des Termins, wie die Teilnehmenden abgestimmt haben.",
     "downloadCsv": "Lade die Tabelle der Teilnehmenden mit ihren Entscheidungen herunter. Du kannst sie in Excel importieren, um deine Veranstaltung besser zu planen.",
     "downloadCsvDescription": "Tabelle als csv Datei herunterladen",
+    "caption": "Terminübersicht",
     "title": {
       "title": "Titel",
       "set": "Gib Deiner Umfrage einen Titel!",

--- a/src/locales/de-DE-du.json
+++ b/src/locales/de-DE-du.json
@@ -98,8 +98,7 @@
     "accepted": "zugesagt",
     "questionable": "vorbehaltlich",
     "declined": "abgelehnt",
-    "undefined": "unbekannt",
-    "unknown": "unbekannt"
+    "undefined": "unbekannt"
   },
   "date": {
     "date": "Termin",

--- a/src/locales/de-DE-du.json
+++ b/src/locales/de-DE-du.json
@@ -118,7 +118,9 @@
     "noStart": "Bitte gib eine gültige Startzeit an. Wenn eine Endezeit angegeben wird, muss eine Startzeit angegeben werden.",
     "inPast": "Bitte gib ein gültiges Startdatum bzw. Startzeitpunkt an. Der Startzeitpunkt muss in der Zukunft liegen.",
     "noValue": "Es muss mindestens eine Terminoption angegeben werden.",
-    "tooManyValues": "Es dürfen nicht mehr als 100 Terminoptionen angegeben werden."
+    "tooManyValues": "Es dürfen nicht mehr als 100 Terminoptionen angegeben werden.",
+    "from": "von",
+    "to": "bis"
   },
   "time": {
     "time": "Uhrzeit",

--- a/src/locales/de-DE-du.json
+++ b/src/locales/de-DE-du.json
@@ -30,6 +30,7 @@
     "testEnvironmentBanner": "Dies ist die Testumgebung von {{value}}. Bitte verwende keine personenbezogenen Daten."
   },
   "poll": {
+    "actions": "Aktionen",
     "poll": "Umfrage",
     "create": "Umfrage erstellen",
     "createNew": "Neue Umfrage erstellen",
@@ -49,6 +50,7 @@
     "editSaveLastStep": "In Schritt \"4\" kannst Du alle Änderungen speichern.",
     "answer": "Beantworte die Umfrage von",
     "addParticipant": "Teilnehmende hinzufügen",
+    "deleteParticipant": "Teilnehmende entfernen",
     "editParticipant": "Teilnehmende hinzufügen",
     "noParticipation": "Ich kann nicht teilnehmen",
     "send": "Abschicken",

--- a/src/locales/de-DE-sie.json
+++ b/src/locales/de-DE-sie.json
@@ -95,6 +95,7 @@
     "accepted": "zugesagt",
     "questionable": "vorbehaltlich",
     "declined": "abgelehnt",
+    "undefined": "unbekannt",
     "unknown": "unbekannt"
   },
   "date": {

--- a/src/locales/de-DE-sie.json
+++ b/src/locales/de-DE-sie.json
@@ -54,6 +54,7 @@
     "send": "Abschicken",
     "downloadIcs": "Laden Sie dieses Datum als .ics-Datei herunter und importieren Sie es in deinen Kalender. Erfahren Sie in der Beschreibung des Termins, wie die Teilnehmer:innen abgestimmt haben.",
     "downloadCsv": "Laden Sie die Tabelle der Teilnehmenden mit ihren Entscheidungen herunter. Sie können sie in Excel importieren, um Ihre Veranstaltung besser zu planen.",
+    "downloadCsvDescription": "Tabelle als csv Datei herunterladen",
     "title": {
       "title": "Titel",
       "set": "Geben Sie Ihrer Umfrage einen Titel!",

--- a/src/locales/de-DE-sie.json
+++ b/src/locales/de-DE-sie.json
@@ -55,6 +55,7 @@
     "downloadIcs": "Laden Sie dieses Datum als .ics-Datei herunter und importieren Sie es in deinen Kalender. Erfahren Sie in der Beschreibung des Termins, wie die Teilnehmer:innen abgestimmt haben.",
     "downloadCsv": "Laden Sie die Tabelle der Teilnehmenden mit ihren Entscheidungen herunter. Sie können sie in Excel importieren, um Ihre Veranstaltung besser zu planen.",
     "downloadCsvDescription": "Tabelle als csv Datei herunterladen",
+    "caption": "Terminübersicht",
     "title": {
       "title": "Titel",
       "set": "Geben Sie Ihrer Umfrage einen Titel!",

--- a/src/locales/de-DE-sie.json
+++ b/src/locales/de-DE-sie.json
@@ -118,7 +118,9 @@
     "noStart": "Bitte geben Sie eine gültige Startzeit an. Wenn eine Endezeit angegeben wird, muss eine Startzeit angegeben werden.",
     "inPast": "Bitte geben Sie ein gültiges Startdatum bzw. Startzeitpunkt an. Der Startzeitpunkt muss in der Zukunft liegen.",
     "noValue": "Es muss mindestens eine Terminoption angegeben werden.",
-    "tooManyValues": "Es dürfen nicht mehr als 100 Terminoptionen angegeben werden."
+    "tooManyValues": "Es dürfen nicht mehr als 100 Terminoptionen angegeben werden.",
+    "from": "von",
+    "to": "bis"
   },
   "time": {
     "time": "Uhrzeit",

--- a/src/locales/de-DE-sie.json
+++ b/src/locales/de-DE-sie.json
@@ -98,8 +98,7 @@
     "accepted": "zugesagt",
     "questionable": "vorbehaltlich",
     "declined": "abgelehnt",
-    "undefined": "unbekannt",
-    "unknown": "unbekannt"
+    "undefined": "unbekannt"
   },
   "date": {
     "date": "Termin",

--- a/src/locales/de-DE-sie.json
+++ b/src/locales/de-DE-sie.json
@@ -49,6 +49,7 @@
     "editSaveLastStep": "In Schritt \"4\" können Sie alle Änderungen speichern.",
     "answer": "Beantworten Sie die Umfrage von",
     "addParticipant": "Teilnehmer:in hinzufügen",
+    "editParticipant": "Teilnehmer:in bearbeiten",
     "noParticipation": "Ich kann nicht teilnehmen",
     "send": "Abschicken",
     "downloadIcs": "Laden Sie dieses Datum als .ics-Datei herunter und importieren Sie es in deinen Kalender. Erfahren Sie in der Beschreibung des Termins, wie die Teilnehmer:innen abgestimmt haben.",

--- a/src/locales/de-DE-sie.json
+++ b/src/locales/de-DE-sie.json
@@ -30,6 +30,7 @@
     "testEnvironmentBanner": "Dies ist die Testumgebung von {{value}}. Bitte verwenden Sie keine personenbezogenen Daten."
   },
   "poll": {
+    "actions": "Aktionen",
     "poll": "Umfrage",
     "create": "Umfrage erstellen",
     "createNew": "Neue Umfrage erstellen",
@@ -49,6 +50,7 @@
     "editSaveLastStep": "In Schritt \"4\" können Sie alle Änderungen speichern.",
     "answer": "Beantworten Sie die Umfrage von",
     "addParticipant": "Teilnehmer:in hinzufügen",
+    "deleteParticipant": "Teilnehmende entfernen",
     "editParticipant": "Teilnehmer:in bearbeiten",
     "noParticipation": "Ich kann nicht teilnehmen",
     "send": "Abschicken",

--- a/src/locales/en-EN.json
+++ b/src/locales/en-EN.json
@@ -30,6 +30,7 @@
     "testEnvironmentBanner": "This is a test environment of {{value}}. Please do not fill in personal data."
   },
   "poll": {
+    "actions": "Actions",
     "poll": "Poll",
     "create": "Create poll",
     "createNew": "Create new poll",
@@ -49,6 +50,7 @@
     "editSaveLastStep": "In step \"4\" you can save your changes.",
     "answer": "Participate at poll of",
     "addParticipant": "Add participant",
+    "deleteParticipant": "Remove participant",
     "editParticipant": "Edit participant",
     "noParticipation": "I can't participate",
     "send": "Send",

--- a/src/locales/en-EN.json
+++ b/src/locales/en-EN.json
@@ -98,8 +98,7 @@
     "accepted": "accepted",
     "questionable": "questionable",
     "declined": "declined",
-    "undefined": "undefined",
-    "unknown": "unknown"
+    "undefined": "unknown"
   },
   "date": {
     "date": "Date",

--- a/src/locales/en-EN.json
+++ b/src/locales/en-EN.json
@@ -95,6 +95,7 @@
     "accepted": "accepted",
     "questionable": "questionable",
     "declined": "declined",
+    "undefined": "undefined",
     "unknown": "unknown"
   },
   "date": {

--- a/src/locales/en-EN.json
+++ b/src/locales/en-EN.json
@@ -49,6 +49,7 @@
     "editSaveLastStep": "In step \"4\" you can save your changes.",
     "answer": "Participate at poll of",
     "addParticipant": "Add participant",
+    "editParticipant": "Edit participant",
     "noParticipation": "I can't participate",
     "send": "Send",
     "downloadIcs": "Download this date as .ics-File to import it to your calendar. Check the voting of your participants in the description.",

--- a/src/locales/en-EN.json
+++ b/src/locales/en-EN.json
@@ -55,6 +55,7 @@
     "downloadIcs": "Download this date as .ics-File to import it to your calendar. Check the voting of your participants in the description.",
     "downloadCsv": "Download the table of participants and their voting. You can import it into Excel and plan your event.",
     "downloadCsvDescription": "Download table as csv file",
+    "caption": "Appointments overview",
     "title": {
       "title": "Title",
       "set": "Set a title!",

--- a/src/locales/en-EN.json
+++ b/src/locales/en-EN.json
@@ -118,7 +118,9 @@
     "noStart": "Please set a start date. If there is an end date, there has to be a start date.",
     "inPast": "Please enter a valid start date. The start date must be in the future.",
     "noValue": "There must be at least one date.",
-    "tooManyValues": "More than 100 dates are not possible."
+    "tooManyValues": "More than 100 dates are not possible.",
+    "from": "from",
+    "to": "to"
   },
   "time": {
     "time": "Time",

--- a/src/locales/en-EN.json
+++ b/src/locales/en-EN.json
@@ -54,6 +54,7 @@
     "send": "Send",
     "downloadIcs": "Download this date as .ics-File to import it to your calendar. Check the voting of your participants in the description.",
     "downloadCsv": "Download the table of participants and their voting. You can import it into Excel and plan your event.",
+    "downloadCsvDescription": "Download table as csv file",
     "title": {
       "title": "Title",
       "set": "Set a title!",

--- a/src/locales/platt.json
+++ b/src/locales/platt.json
@@ -50,7 +50,8 @@
     "noParticipation": "Ik kann nich deelnehmen",
     "send": "Afschicken",
     "downloadIcs": "Lader vun dissen Dag as ics-Datei dal un importeer dat in dien Kalenner.",
-    "downloadCsv": ".",
+    "downloadCsv": "Lader de Tabelle vun alle Deelnehmer mit deren Entscheedungen rünner. De Datei kanns du inn Excel importeern, um dien Veranstaltung bedder to planen",
+    "downloadCsvDescription": "Tabelle als csv Datei rünnerladen",
     "title": {
       "title": "Titel",
       "set": "Geev Diner Umfraag en Titel!",

--- a/src/locales/platt.json
+++ b/src/locales/platt.json
@@ -52,6 +52,7 @@
     "downloadIcs": "Lader vun dissen Dag as ics-Datei dal un importeer dat in dien Kalenner.",
     "downloadCsv": "Lader de Tabelle vun alle Deelnehmer mit deren Entscheedungen rünner. De Datei kanns du inn Excel importeern, um dien Veranstaltung bedder to planen",
     "downloadCsvDescription": "Tabelle als csv Datei rünnerladen",
+    "caption": "Terminöversicht",
     "title": {
       "title": "Titel",
       "set": "Geev Diner Umfraag en Titel!",

--- a/src/locales/platt.json
+++ b/src/locales/platt.json
@@ -46,6 +46,7 @@
     "editSaveLastStep": "In Schritt \"4\" kannst Du all Ännern lagern.",
     "answer": "Beantwoort de Umfraag vun",
     "addParticipant": "Deelnehmer:in tügen",
+    "editParticipant": "Deelnehmer:in ännern",
     "noParticipation": "Ik kann nich deelnehmen",
     "send": "Afschicken",
     "downloadIcs": "Lader vun dissen Dag as ics-Datei dal un importeer dat in dien Kalenner.",

--- a/src/locales/platt.json
+++ b/src/locales/platt.json
@@ -85,6 +85,7 @@
     "accepted": ".",
     "questionable": ".",
     "declined": ".",
+    "undefined": ".",
     "unknown": "."
   },
   "date": {

--- a/src/locales/platt.json
+++ b/src/locales/platt.json
@@ -111,7 +111,9 @@
     "noStart": "Bitte giff en gültig Starttiet an. Wenn en Enn angeven warrt, mutt en Starttiet angeven warrn.",
     "inPast": "Bitte giff en gültig Startdatum bzw. Startstiet an. De Startstiet muss in de Tokunft liggen.",
     "noValue": "Dat mutt mindst en Termin angeven warrn.",
-    "tooManyValues": "Dat drööft nich mehr as 100 Terminschonen angeven warrn."
+    "tooManyValues": "Dat drööft nich mehr as 100 Terminschonen angeven warrn.",
+    "from": "vun",
+    "to": "to"
   },
   "time": {
     "time": "Uhrtied",

--- a/src/locales/platt.json
+++ b/src/locales/platt.json
@@ -86,8 +86,7 @@
     "accepted": ".",
     "questionable": ".",
     "declined": ".",
-    "undefined": ".",
-    "unknown": "."
+    "undefined": "."
   },
   "date": {
     "date": "Termin",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -292,13 +292,9 @@ a,
   }
 
   .poll-summary-data-cell {
-    .voting-status-summary-image {
-      margin-right: 4px;
-
-      img {
-        height: $form-status-icon-height-small;
-        width: $form-status-icon-width-small;
-      }
+    .voting-status-summary-image img {
+      height: $form-status-icon-height-small;
+      width: $form-status-icon-width-small;
     }
 
     .voting-status-summary-number {


### PR DESCRIPTION
## features
- add `tfoot` which contains the download buttons
- add column for actions on the participant
- add title for edit buttons
- add alt text for voting option
- refactor table headings to include multiple rows & columns with matching scope
- the visually short format of the suggested dates now reads fully to screenreaders
- add table caption
- add title and describedby to buttons
- make delete button pressable by keyboard 'enter'
- add border on mobile table for each row

## fixes
- poll options get recognized as radio group
- remove alt texts for images with aria-hidden set to true
- start time now present on mobile on all possible variants
- centered what I could find
- add more space to elements too close together

## other
- hyphen between times isn't a '-' anymore which gets pushed around, now it's a colored DIV which knows where to be

closes #310 #311 