### PR TITLE
fix: disable unsupported feature until backend is ready

### DIFF
--- a/cypress/e2e/create-dates-view.cy.ts
+++ b/cypress/e2e/create-dates-view.cy.ts
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 import * as dayjs from 'dayjs';
 import * as utc from 'dayjs/plugin/utc';
-import values from "../fixtures/values.json";
+// import values from "../fixtures/values.json";
 
 dayjs.extend(utc);
 
@@ -21,8 +21,9 @@ context('create-dates-view', () => {
       cy.get('[data-id=startDateInput]');
       cy.get('[data-id=addTimesButton]');
       cy.get('[data-id=endAtOtherDayButton]');
-      cy.get('[data-id=descriptionLabel]');
-      cy.get('[data-id=descriptionInput]');
+      // TODO disabled until backend supports feature
+      // cy.get('[data-id=descriptionLabel]');
+      // cy.get('[data-id=descriptionInput]');
       cy.get('[data-id=addSuggestedDateButton]');
       cy.get('[data-id=back]')
         .should('be.enabled');
@@ -321,18 +322,19 @@ context('create-dates-view', () => {
         .clear();
     });
 
-    it('Accepts valid description', () => {
-      cy.get('[data-id=descriptionInput]')
-        .type('Test-Beschreibung', {delay: 0})
-        .should('have.value', 'Test-Beschreibung');
-    });
-
-    it('Does not accept too long description', () => {
-      cy.get('[data-id=descriptionTooLong]').should('not.exist');
-      cy.get('[data-id=descriptionInput]')
-        .type(values.tooLongString, {delay: 0});
-      cy.get('[data-id=descriptionTooLong]');
-    });
+    // TODO disabled until backend supports feature
+    // it('Accepts valid description', () => {
+    //   cy.get('[data-id=descriptionInput]')
+    //     .type('Test-Beschreibung', {delay: 0})
+    //     .should('have.value', 'Test-Beschreibung');
+    // });
+    //
+    // it('Does not accept too long description', () => {
+    //   cy.get('[data-id=descriptionTooLong]').should('not.exist');
+    //   cy.get('[data-id=descriptionInput]')
+    //     .type(values.tooLongString, {delay: 0});
+    //   cy.get('[data-id=descriptionTooLong]');
+    // });
   });
 
   describe('Adds new suggested date', () => {


### PR DESCRIPTION
e2e tests were missing https://github.com/Dataport/terminfinder-frontend/pull/340