### PR TITLE
Fix: poll options breaking layout on smaller display sizes

### DIFF
--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -87,7 +87,7 @@
             <!-- suggested date -->
             <td class="suggested-date pl-3">
               <div class="row g-0">
-                <div [ngClass]="formHelper.hasAddOrEditParticipantForm() ? 'col-12' : 'col-8'">
+                <div class="col">
                   <app-suggested-date [date]="date" [index]="i"></app-suggested-date>
                 </div>
                 @if (!formHelper.hasAddOrEditParticipantForm()) {

--- a/src/app/poll/mobile-poll-table.component.html
+++ b/src/app/poll/mobile-poll-table.component.html
@@ -87,25 +87,27 @@
             <!-- suggested date -->
             <td class="suggested-date pl-3">
               <div class="row g-0">
-                <div class="col-8">
+                <div [ngClass]="formHelper.hasAddOrEditParticipantForm() ? 'col-12' : 'col-8'">
                   <app-suggested-date [date]="date" [index]="i"></app-suggested-date>
                 </div>
-                <div class="col-4 d-flex justify-content-center align-items-center">
-                <button
-                  (click)="formHelper.downloadCal(date, i)"
-                  class="download-cal btn btn-rounded btn-sm btn-light"
-                  data-placement="top"
-                  data-toggle="tooltip"
-                  title="{{ 'poll.downloadIcs' | translate }}"
-                  type="button"
-                >
-                  <img alt="{{ 'poll.downloadIcs' | translate }}" aria-hidden="true" src="assets/download.svg">
-                </button>
-                </div>
+                @if (!formHelper.hasAddOrEditParticipantForm()) {
+                  <div class="col-4 d-flex justify-content-center align-items-center">
+                    <button
+                      (click)="formHelper.downloadCal(date, i)"
+                      class="download-cal btn btn-rounded btn-sm btn-light"
+                      data-placement="top"
+                      data-toggle="tooltip"
+                      title="{{ 'poll.downloadIcs' | translate }}"
+                      type="button"
+                    >
+                      <img alt="{{ 'poll.downloadIcs' | translate }}" aria-hidden="true" src="assets/download.svg">
+                    </button>
+                  </div>
+                }
               </div>
             </td>
             <td class="total-participants">
-              <div class="mx-4 d-flex justify-content-between align-items-center">
+              <div class="px-1 d-flex justify-content-start align-items-center">
                 <div class="voting-status-summary-image">
                   <img alt="checkmark" aria-hidden="true" src="assets/status_accepted.svg">
                 </div>
@@ -114,7 +116,7 @@
                 </div>
               </div>
             </td>
-            <td class="poll-options pr-2">
+            <td class="poll-options">
               <!--suppress HtmlUnknownTarget the image path is generated dynamically -->
               @if (!formHelper.hasAddOrEditParticipantForm() && getSelectedParticipant()) {
                 <img

--- a/src/app/poll/mobile-poll-table.component.scss
+++ b/src/app/poll/mobile-poll-table.component.scss
@@ -42,6 +42,10 @@
 
 .poll-table td.total-participants {
   padding: 0;
+
+  .voting-status-summary-number {
+    font-size: 1.8rem;
+  }
 }
 
 .poll-table.mobile td.poll-options {
@@ -55,4 +59,17 @@
 
 .voting-status-summary-image img {
   display: block;
+}
+
+@media (max-width: 300px) {
+  .poll-table td.total-participants {
+    .voting-status-summary-number {
+      font-size: 1.35rem;
+    }
+
+    .voting-status-summary-image img {
+      width: $poll-option-width-small * 0.75;
+      height: $poll-option-width-small * 0.75;
+    }
+  }
 }

--- a/src/app/poll/mobile-poll-table.component.scss
+++ b/src/app/poll/mobile-poll-table.component.scss
@@ -44,9 +44,13 @@
   padding: 0;
 }
 
-.poll-table.mobile td.poll-options > img {
-  margin-left: auto;
-  margin-right: 1rem;
+.poll-table.mobile td.poll-options {
+  min-width: max-content;
+
+  > img {
+    margin-left: auto;
+    margin-right: 1rem;
+  }
 }
 
 .voting-status-summary-image img {

--- a/src/app/poll/poll.component.html
+++ b/src/app/poll/poll.component.html
@@ -21,8 +21,8 @@
 }
 @if (formHelper) {
   <form [formGroup]="formHelper.pollForm">
-    <div class="row mx-3">
-      <div class="col">
+    <div class="row mx-md-3 mx-sm-1">
+      <div class="col p-sm-2">
         @if (model) {
           <div class="section-container">
             <div class="pt-2 px-3">

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -207,7 +207,6 @@ button.btn-with-image {
     vertical-align: middle;
     font-size: 1.8rem;
     padding: 0;
-    width: 50px;
   }
 
   th,

--- a/src/app/shared/components/poll-options/poll-options.component.html
+++ b/src/app/shared/components/poll-options/poll-options.component.html
@@ -1,6 +1,6 @@
 @if (formGroup !== null) {
   <div class="row g-1">
-    <div class="col col-4 d-flex justify-content-center">
+    <div class="col-4 d-flex justify-content-center">
       <img
         alt=""
         aria-hidden="true"
@@ -8,7 +8,7 @@
         src="assets/status_declined.svg"
       >
     </div>
-    <div class="col col-4 d-flex justify-content-center">
+    <div class="col-4 d-flex justify-content-center">
       <img
         alt=""
         aria-hidden="true"
@@ -16,7 +16,7 @@
         src="assets/status_questionable.svg"
       >
     </div>
-    <div class="col col-4 d-flex justify-content-center">
+    <div class="col-4 d-flex justify-content-center">
       <img
         alt=""
         aria-hidden="true"
@@ -26,7 +26,7 @@
     </div>
   </div>
   <div [formGroup]="formGroup" class="row g-1 mt-1">
-    <div class="col col-4">
+    <div class="col-4">
       <div class="d-flex justify-content-center">
         <input
           class=""
@@ -39,7 +39,7 @@
         >
       </div>
     </div>
-    <div class="col col-4">
+    <div class="col-4">
       <div class="d-flex justify-content-center">
         <input
           class=""
@@ -53,7 +53,7 @@
         >
       </div>
     </div>
-    <div class="col col-4">
+    <div class="col-4">
       <div class="d-flex justify-content-center">
         <input
           class=""

--- a/src/app/shared/components/poll-options/poll-options.component.html
+++ b/src/app/shared/components/poll-options/poll-options.component.html
@@ -1,6 +1,6 @@
 @if (formGroup !== null) {
-  <div class="row">
-    <div class="col d-flex justify-content-center">
+  <div class="row g-1">
+    <div class="col col-4 d-flex justify-content-center">
       <img
         alt=""
         aria-hidden="true"
@@ -8,7 +8,7 @@
         src="assets/status_declined.svg"
       >
     </div>
-    <div class="col d-flex justify-content-center">
+    <div class="col col-4 d-flex justify-content-center">
       <img
         alt=""
         aria-hidden="true"
@@ -16,7 +16,7 @@
         src="assets/status_questionable.svg"
       >
     </div>
-    <div class="col d-flex justify-content-center">
+    <div class="col col-4 d-flex justify-content-center">
       <img
         alt=""
         aria-hidden="true"
@@ -25,8 +25,8 @@
       >
     </div>
   </div>
-  <div [formGroup]="formGroup" class="row mt-1">
-    <div class="col">
+  <div [formGroup]="formGroup" class="row g-1 mt-1">
+    <div class="col col-4">
       <div class="d-flex justify-content-center">
         <input
           class=""
@@ -39,7 +39,7 @@
         >
       </div>
     </div>
-    <div class="col">
+    <div class="col col-4">
       <div class="d-flex justify-content-center">
         <input
           class=""
@@ -53,7 +53,7 @@
         >
       </div>
     </div>
-    <div class="col">
+    <div class="col col-4">
       <div class="d-flex justify-content-center">
         <input
           class=""


### PR DESCRIPTION
Basically using available space better or creating it when necessary.

- refactor poll options spacing
- hide download button in edit-mode for more space | Thought on this is that the result will change anyway when the user is done editing. 
- remove fixed `width` for `.total-participants`
- remove paddings without effect
- set `min-width` for `.poll-options` so the layout will never break
- give options more space with `.g-1`
- resize summary number on smaller display sizes
- decrease form margin & padding when on `sm` display size