### PR TITLE
feat: exclude selected routes from translation

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -51,13 +51,14 @@
         <li>
           <app-combobox
             [label]="'lang.languageSelect' | translate"
-            [callback]="changeLanguage.bind(this)"
+            [callback]="this.localeService.changeLanguage.bind(this.localeService)"
             [options]="[
               {value: 'Deutsch', callbackArgs: 'de-DE', dataId: 'langGerman'},
               {value: 'English', callbackArgs: 'en-EN', dataId: 'langEnglish'}
             ]"
             [defaultOptionIndex]="localeService.getLocale().languageCode === 'de-DE' ? 0 : 1"
             [dataId]="'languageDropdown'"
+            id="language-dropdown"
           />
         </li>
       </ul>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,6 @@ import './operators';
 import {environment} from '../environments/environment';
 import {Logger} from './shared/services/logging';
 import {Title} from '@angular/platform-browser';
-import {TranslateService} from '@ngx-translate/core';
 import {LocalStorageService} from './shared/services/data-service/local-storage.service';
 import {LocaleService} from './shared/services/locale/locale.service';
 
@@ -21,7 +20,6 @@ export class AppComponent implements OnInit {
     public localeService: LocaleService,
     private logger: Logger,
     private titleService: Title,
-    private translateService: TranslateService,
     private localStorageService: LocalStorageService,
   ) {
   }
@@ -32,13 +30,13 @@ export class AppComponent implements OnInit {
 
     const lang = this.localStorageService.get('language');
     this.logger.debug('LANG: ', lang);
-    this.localeService.initLanguage(lang);
 
-    this.translateService.onLangChange
-      .subscribe(
-        _ => {},
-        _ => {
-        this.connectionError = true;
+    this.localeService
+      .initLanguage(lang)
+      .subscribe({
+        error: _ => {
+          this.connectionError = true;
+        }
       });
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,7 +2,6 @@ import {Component, OnInit} from '@angular/core';
 import './operators';
 import {environment} from '../environments/environment';
 import {Logger} from './shared/services/logging';
-import * as moment from 'moment';
 import {Title} from '@angular/platform-browser';
 import {TranslateService} from '@ngx-translate/core';
 import {LocalStorageService} from './shared/services/data-service/local-storage.service';
@@ -30,34 +29,16 @@ export class AppComponent implements OnInit {
   ngOnInit(): void {
     this.logger.debug('ENV: ', environment);
     this.titleService.setTitle(environment.title);
+
     const lang = this.localStorageService.get('language');
     this.logger.debug('LANG: ', lang);
-    if (lang) {
-      this.changeLanguage(lang);
-    } else {
-      this.changeLanguage(navigator.language);
-    }
-  }
+    this.localeService.initLanguage(lang);
 
-  changeLanguage(locale: string): void {
-    const newLocale = this.localeService.setLocale(locale);
-    let languageCodeWithAddressing: string;
-
-    if (newLocale.languageCode === 'de-DE') {
-      languageCodeWithAddressing = newLocale.languageCode + '-' + newLocale.addressing;
-    } else {
-      languageCodeWithAddressing = newLocale.languageCode;
-    }
-
-    this.translateService.use(languageCodeWithAddressing).subscribe(
-      _ => {
-      },
-      _ => {
+    this.translateService.onLangChange
+      .subscribe(
+        _ => {},
+        _ => {
         this.connectionError = true;
-      }
-    );
-    moment.locale(newLocale.languageCode);
-    this.localStorageService.set('language', newLocale.languageCode);
-    document.querySelector('html')?.setAttribute('lang', this.localeService.getIsoLanguageCode());
+      });
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,6 +38,7 @@ import {
   AppointmentIdRequiredGuard,
   CanDeactivateGuard,
   DatesRequiredGuard,
+  DefaultLanguageGuard,
   NameRequiredGuard,
   PasswordRequiredGuard,
   TitleRequiredGuard
@@ -131,9 +132,24 @@ export const appRoutes: Routes = [
   {path: 'admin/overview', component: AdminOverviewComponent, canActivate: [DatesRequiredGuard]},
   {path: 'admin/links', component: AdminLinksComponent, canActivate: [AppointmentIdRequiredGuard]},
   {path: 'admin/settings', component: AdminSettingsComponent, canActivate: [DatesRequiredGuard]},
-  {path: 'imprint', component: ImprintComponent},
-  {path: 'privacy', component: PrivacyComponent},
-  {path: 'accessibility', component: AccessibilityComponent},
+  {
+    path: 'imprint',
+    component: ImprintComponent,
+    canActivate: [DefaultLanguageGuard],
+    canDeactivate: [DefaultLanguageGuard]
+  },
+  {
+    path: 'privacy',
+    component: PrivacyComponent,
+    canActivate: [DefaultLanguageGuard],
+    canDeactivate: [DefaultLanguageGuard]
+  },
+  {
+    path: 'accessibility',
+    component: AccessibilityComponent,
+    canActivate: [DefaultLanguageGuard],
+    canDeactivate: [DefaultLanguageGuard]
+  },
   {path: 'termsOfService', component: TermsOfServiceComponent},
   {path: 'plain-language', component: PlainLanguageComponent},
   {path: 'sign-language', component: SignLanguageComponent},

--- a/src/app/shared/components/combobox/combobox.component.scss
+++ b/src/app/shared/components/combobox/combobox.component.scss
@@ -23,6 +23,10 @@
   &.open::after {
     transform: rotate(180deg);
   }
+
+  &.disabled {
+    border-color: transparent;
+  }
 }
 
 .open .listbox {

--- a/src/app/shared/services/locale/locale.service.ts
+++ b/src/app/shared/services/locale/locale.service.ts
@@ -84,25 +84,23 @@ export class LocaleService {
 
   initLanguage(lang: string) {
     if (!NullableUtils.isStringNullOrWhitespace(lang)) {
-      this.changeLanguage(lang);
+      return this.changeLanguage(lang);
     } else {
-      this.changeLanguage(navigator.language);
+      return this.changeLanguage(navigator.language);
     }
   }
 
-  changeLanguage(locale: string, setLocalStorage = true): void {
+  changeLanguage(locale: string, setLocalStorage = true) {
     this.setLocale(locale);
-
-    this.translateService
-      .use(this.getLanguageCodeWithAddressing())
-      .subscribe(_ => {});
-
-    moment.locale(this._locale.languageCode);
-    document.querySelector('html')?.setAttribute('lang', this.getIsoLanguageCode());
 
     if (setLocalStorage) {
       this.localStorageService.set('language', this._locale.languageCode);
     }
+
+    moment.locale(this._locale.languageCode);
+    document.querySelector('html')?.setAttribute('lang', this.getIsoLanguageCode());
+
+    return this.translateService.use(this.getLanguageCodeWithAddressing());
   }
 
   getLanguageCodeWithAddressing() {

--- a/src/app/shared/services/locale/locale.service.ts
+++ b/src/app/shared/services/locale/locale.service.ts
@@ -3,6 +3,10 @@ import {registerLocaleData} from '@angular/common';
 import localeGerman from '@angular/common/locales/de';
 import localeEnglish from '@angular/common/locales/en';
 import {environment} from "../../../../environments/environment";
+import moment from "moment/moment";
+import {TranslateService} from "@ngx-translate/core";
+import {LocalStorageService} from "../data-service/local-storage.service";
+import {NullableUtils} from "../../utils";
 
 export type LanguageCode = 'de-DE' | 'en-EN';
 export type Addressing = 'du' | 'sie';
@@ -14,13 +18,17 @@ export interface Locale {
 
 @Injectable({providedIn: 'root'})
 export class LocaleService {
+  private readonly DEFAULT_LOCALE: string = 'de-DE';
 
   private _locale: Locale = {
     languageCode: 'de-DE',
     addressing: 'du'
   };
 
-  constructor() {
+  constructor(
+    private translateService: TranslateService,
+    private localStorageService: LocalStorageService,
+  ) {
     if (environment.locale === 'en-EN') {
       this._locale.languageCode = 'en-EN';
     }
@@ -44,10 +52,8 @@ export class LocaleService {
     return this._locale;
   }
 
-  setLocale(languageCode?: string, addressing?: string): Locale {
-    if (!languageCode && !addressing) {
-      return this._locale;
-    }
+  setLocale(languageCode?: string, addressing?: string): void {
+    if (!languageCode && !addressing) return;
 
     switch (languageCode) {
       case 'de-du':
@@ -74,7 +80,53 @@ export class LocaleService {
         this._locale.addressing = 'sie';
         break;
     }
+  }
 
-    return this._locale;
+  initLanguage(lang: string) {
+    if (!NullableUtils.isStringNullOrWhitespace(lang)) {
+      this.changeLanguage(lang);
+    } else {
+      this.changeLanguage(navigator.language);
+    }
+  }
+
+  changeLanguage(locale: string, setLocalStorage = true): void {
+    this.setLocale(locale);
+
+    this.translateService
+      .use(this.getLanguageCodeWithAddressing())
+      .subscribe(_ => {});
+
+    moment.locale(this._locale.languageCode);
+    document.querySelector('html')?.setAttribute('lang', this.getIsoLanguageCode());
+
+    if (setLocalStorage) {
+      this.localStorageService.set('language', this._locale.languageCode);
+    }
+  }
+
+  getLanguageCodeWithAddressing() {
+    if (this._locale.languageCode === 'de-DE') {
+      return this._locale.languageCode + '-' + this._locale.addressing;
+    } else {
+      return this._locale.languageCode;
+    }
+  }
+
+  useDefaultLanguage() {
+    this.changeLanguage(this.DEFAULT_LOCALE, false);
+
+    const languageDropdown = document.querySelector('#language-dropdown .combobox');
+    languageDropdown.setAttribute('aria-disabled', 'true');
+    languageDropdown.classList.add('disabled');
+  }
+
+  useStoredLanguage() {
+    const lang = this.localStorageService.get('language') ?? this.DEFAULT_LOCALE;
+    this.changeLanguage(lang);
+
+    const languageDropdown = document.querySelector('#language-dropdown .combobox');
+    languageDropdown.setAttribute('aria-disabled', 'false');
+    languageDropdown.classList.remove('disabled');
   }
 }

--- a/src/app/shared/services/navigation-guard/navigation-guard.service.ts
+++ b/src/app/shared/services/navigation-guard/navigation-guard.service.ts
@@ -10,6 +10,7 @@ import {AppointmentProtectionResult} from '../../models/api-data-v1-dto';
 import {NullableUtils} from '../../utils';
 import {AppointmentPasswordValidationResult} from '../../models/api-data-v1-dto/appointmentPasswordValidationResult';
 import {TranslateService} from "@ngx-translate/core";
+import {LocaleService} from "../locale/locale.service";
 
 @Injectable({
   providedIn: 'root'
@@ -165,5 +166,23 @@ export class PasswordRequiredGuard {
       this.appStateService.isAdmin = false;
     }
     this.appStateService.updateAppointment(appointment);
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DefaultLanguageGuard {
+  constructor(private localeService: LocaleService) {
+  }
+
+  canActivate(): boolean {
+    this.localeService.useDefaultLanguage();
+    return true;
+  }
+
+  canDeactivate(): boolean {
+    this.localeService.useStoredLanguage();
+    return true;
   }
 }


### PR DESCRIPTION
When an excluded route is visited:
- use default language
- disable language dropdown

- move language handling to `locale.service.ts`