### PR TITLE
refactor: use relative font-sizes

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -23,7 +23,7 @@
 .connectionError {
   margin-left: auto;
   margin-right: auto;
-  font-size: 20px !important;
+  font-size: 1.25rem !important;
   background-color: #f6ccdb;
 }
 

--- a/src/app/poll/poll.component.scss
+++ b/src/app/poll/poll.component.scss
@@ -192,7 +192,7 @@ button.btn-with-image {
     }
 
     .download-cal {
-      font-size: 16px !important;
+      font-size: 1rem !important;
     }
   }
 

--- a/src/default.scss
+++ b/src/default.scss
@@ -46,11 +46,11 @@ $suggested-date-desktop-min-width: 140px;
 $suggested-date-desktop-max-width: 160px;
 $suggested-date-mobile-min-width: 70px;
 $suggested-date-mobile-max-width: 100px;
-$font-size-small: 16px;
+$font-size-small: 1rem; /* Baseline font-size: 16px */
 $small-font-size: $font-size-small;
-$font-size-medium: 20px;
-$font-size-large: 32px;
-$font-size-x-large: 32px;
+$font-size-medium: 1.275rem;
+$font-size-large: 2rem;
+$font-size-x-large: 2rem;
 $font-size-small-mobile: 12pt;
 $font-size-medium-mobile: 13pt;
 $font-size-large-mobile: 15pt;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -59,6 +59,13 @@ label {
   font-weight: $font-weight-bold !important;
 }
 
+// ensures correct scaling when users set custom font-sizes
+button.btn:has(img),
+.voting-status-summary-image {
+  line-height: 1 !important;
+  font-size: 1rem !important;
+}
+
 .invalid-message {
   font-size: $font-size-small-mobile;
   @include media-breakpoint-up(lg) {


### PR DESCRIPTION
When users set custom font-sizes in their browser, fixed sizes in `px` won't scale.