### PR TITLE
Fix: mobile header

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,9 +11,11 @@
         height="height"
         width="width">
     </a>
-    <div class="col-xs-12 col-sm-6 col-lg h1 my-md-auto" data-id="headerTitle">
-      {{ headlineHome }}
-    </div>
+    @if (!NullableUtils.isStringNullOrWhitespace(headlineHome)) {
+      <div class="col-xs-12 col-sm-6 col-lg h1 my-md-auto" data-id="headerTitle">
+        {{ headlineHome }}
+      </div>
+    }
     <nav class="col-12 col-lg" [attr.aria-label]="'header.navLabel' | translate">
       <ul class="d-flex flex-row flex-wrap list-unstyled justify-content-end align-items-baseline gap-1 mb-0">
         <li>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
 <div class="container flex-grow-1">
   <header class="row justify-content-center align-items-center" id="head">
-    <a class="col-2 col-md-3 w-auto" routerLink="/">
+    <a class="col-xs-12 col-sm-6 col-lg" routerLink="/">
       <span class="sr-only">{{ 'header.home' | translate }}</span>
       <img
         aria-hidden="true"
@@ -11,10 +11,10 @@
         height="height"
         width="width">
     </a>
-    <div class="col header-title h1" data-id="headerTitle">
+    <div class="col-xs-12 col-sm-6 col-lg h1 my-md-auto" data-id="headerTitle">
       {{ headlineHome }}
     </div>
-    <nav class="col-2 col-md-3" [attr.aria-label]="'header.navLabel' | translate">
+    <nav class="col-12 col-lg" [attr.aria-label]="'header.navLabel' | translate">
       <ul class="d-flex flex-row flex-wrap list-unstyled justify-content-end align-items-baseline gap-1 mb-0">
         <li>
           <a

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -19,11 +19,6 @@
   }
 }
 
-.header-title {
-  margin-top: auto;
-  margin-bottom: auto;
-}
-
 .connectionError {
   margin-left: auto;
   margin-right: auto;

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -9,10 +9,14 @@
 
 #logo {
   margin-left: 0;
-  padding-left: 0.5rem;
-  width: $head-logo-width;
-  height: $head-logo-height;
+  width: 100%;
   object-fit: contain;
+  max-height: $head-logo-height;
+
+  @include media-breakpoint-up(md) {
+    width: $head-logo-width;
+    height: $head-logo-height;
+  }
 }
 
 .header-title {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,6 +5,7 @@ import {Logger} from './shared/services/logging';
 import {Title} from '@angular/platform-browser';
 import {LocalStorageService} from './shared/services/data-service/local-storage.service';
 import {LocaleService} from './shared/services/locale/locale.service';
+import {NullableUtils} from "./shared/utils";
 
 @Component({
   selector: 'app-root',
@@ -12,6 +13,7 @@ import {LocaleService} from './shared/services/locale/locale.service';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit {
+  protected readonly NullableUtils = NullableUtils;
 
   connectionError = false;
   headlineHome = environment.title;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,7 +22,7 @@ body {
 h1 {
   color: $primary !important;
   font-weight: $font-weight-bold !important;
-  font-size: $font-size-small-mobile !important;
+  font-size: $font-size-large-mobile !important;
   @include media-breakpoint-up(sm) {
     font-size: $font-size-large !important;
   }


### PR DESCRIPTION
- fix header layout on xs screen sizes
- refactor column flow

On `xs`:
Each element is in a row.

On `sm` to `lg`:
Logo & title
\-------------
nav

On `lg`:
No change in behaviour