### PR TITLE
fix: status 'declined' not being set

### DIFF
--- a/src/app/shared/components/poll-options/poll-options.component.html
+++ b/src/app/shared/components/poll-options/poll-options.component.html
@@ -1,67 +1,30 @@
 @if (formGroup !== null) {
   <div class="row g-1">
+    @for (status of votingStatus; track status) {
     <div class="col-4 d-flex justify-content-center">
       <img
         aria-hidden="true"
         alt=""
         class="poll-option-icon"
-        src="assets/status_declined.svg">
+        [src]="'assets/status_' + status + '.svg'">
     </div>
-    <div class="col-4 d-flex justify-content-center">
-      <img
-        aria-hidden="true"
-        alt=""
-        class="poll-option-icon"
-        src="assets/status_questionable.svg">
-    </div>
-    <div class="col-4 d-flex justify-content-center">
-      <img
-        aria-hidden="true"
-        alt=""
-        class="poll-option-icon"
-        src="assets/status_accepted.svg">
-    </div>
+    }
   </div>
   <div [formGroup]="formGroup" class="row g-1 mt-1">
-    <div class="col-4">
-      <div class="d-flex justify-content-center">
-        <input
-          class=""
-          id="{{getPrefix()}}-voting-status-declined-{{selectorId}}"
-          formControlName="status"
-          [attr.name]="getPrefix() + '-voting-status-' + selectorId"
-          type="radio"
-          value="declined"
-          [attr.aria-label]="'votingStatus.declined' | translate"
-        >
+    @for (status of votingStatus; track status) {
+      <div class="col-4">
+        <div class="d-flex justify-content-center">
+          <input
+            class=""
+            type="radio"
+            id="{{getPrefix()}}-voting-status-{{status}}-{{selectorId}}"
+            formControlName="status"
+            [attr.name]="getPrefix() + '-voting-status-' + selectorId"
+            value="{{status}}"
+            [attr.aria-label]="'votingStatus.' + status | translate"
+          >
+        </div>
       </div>
-    </div>
-    <div class="col-4">
-      <div class="d-flex justify-content-center">
-        <input
-          class=""
-          type="radio"
-          id="{{getPrefix()}}-voting-status-questionable-{{selectorId}}"
-          formControlName="status"
-          [attr.name]="getPrefix() + '-voting-status-' + selectorId"
-          value="questionable"
-          [attr.aria-label]="'votingStatus.questionable' | translate"
-          checked
-        >
-      </div>
-    </div>
-    <div class="col-4">
-      <div class="d-flex justify-content-center">
-        <input
-          class=""
-          type="radio"
-          id="{{getPrefix()}}-voting-status-accepted-{{selectorId}}"
-          formControlName="status"
-          [attr.name]="getPrefix() + '-voting-status-' + selectorId"
-          value="accepted"
-          [attr.aria-label]="'votingStatus.accepted' | translate"
-        >
-      </div>
-    </div>
+    }
   </div>
 }

--- a/src/app/shared/components/poll-options/poll-options.component.ts
+++ b/src/app/shared/components/poll-options/poll-options.component.ts
@@ -10,6 +10,7 @@ export class PollOptionsComponent {
   @Input() formGroup: UntypedFormGroup;
   @Input() selectorId: string;
   @Input() isMobile: boolean;
+  votingStatus = ['declined', 'questionable', 'accepted'];
 
   constructor() {
   }
@@ -21,5 +22,4 @@ export class PollOptionsComponent {
       return 'desktop';
     }
   }
-
 }


### PR DESCRIPTION
When initializing radio buttons for the poll options, the status 'declined' didn't get set, each other status did. Clicking on a (previously empty) declined option resulted in each other declined answer being set correctly. The underlying data was correct in each step to initialization, only the template component didn't set correctly. I couldn't figure out the exact cause, but with this refactoring the bug is gone.