### PR TITLE
refactor: checkbox position always before text

### DIFF
--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -26,8 +26,7 @@
         <div class="row g-0">
           <h2 class="my-1 font-medium text-bold" data-id="generatePassword">{{ 'password.generate' | translate }}</h2>
         </div>
-        <app-checkbox-field [label]="'password.securePoll' | translate" [reverse]="true" data-id="securePollLabel"
-                            formControlName="hasPassword"/>
+        <app-checkbox-field [label]="'password.securePoll' | translate" data-id="securePollLabel" formControlName="hasPassword"/>
         @if (hasPassword().value) {
           <div class="row g-0 pt-3">
             <div class="col-11 offset-1">

--- a/src/app/shared/components/checkbox-field/checkbox-field.component.ts
+++ b/src/app/shared/components/checkbox-field/checkbox-field.component.ts
@@ -14,7 +14,7 @@ import {NgTemplateOutlet} from "@angular/common";
     NgTemplateOutlet
   ],
   template: `
-    <div [class]="reverse ? 'form-check-reverse' : 'form-check'">
+    <div class="form-check">
       <input
         [required]="required"
         [formControl]="ngControl.control"
@@ -25,7 +25,7 @@ import {NgTemplateOutlet} from "@angular/common";
         value=""
         [attr.aria-describedby]="ariaDescribedBy"
       >
-      <label for="checkbox" class="form-check-label w-100 multiline" [class.text-start]="reverse">
+      <label for="checkbox" class="form-check-label w-100 multiline">
         @if (labelTemplate) {
           <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
         } @else {
@@ -44,9 +44,7 @@ export class CheckboxFieldComponent {
   @Input()
   labelTemplate: TemplateRef<any> | undefined;
   @Input()
-  reverse = false;
-  @Input()
   ariaDescribedBy = '';
   @Input()
-  required : string = null;
+  required: string = null;
 }


### PR DESCRIPTION
Display checkbox always before the label to associate it with a possible action. Also users with a screen magnifier may not see the checkbox when its behind the label.

Removed `reverse` @Input because it's not being used again.