### PR TITLE
fix: image too wide

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -15,6 +15,7 @@
 
   @include media-breakpoint-up(md) {
     width: $head-logo-width;
+    max-width: 25rem;
     height: $head-logo-height;
   }
 }


### PR DESCRIPTION
Really narrow logos could overlap into the titles space