### PR TITLE
fix: `<caption>` breaking keyboard table navigation

### DIFF
--- a/src/app/shared/components/dates-overview/dates-overview.component.html
+++ b/src/app/shared/components/dates-overview/dates-overview.component.html
@@ -2,10 +2,9 @@
   <div class="date-time-overview mt-2 table-responsive">
     <table class="table table-borderless d-inline-block mt-1" data-id="overviewDates">
       <thead>
-      <caption class="visually-hidden">{{ 'poll.caption' | translate }}</caption>
       <tr>
         @for (date of appointment.suggestedDates; track date; let i = $index) {
-          <th scope="row">
+          <th>
             {{ 'date.date' | translate }} {{ i + 1 }}
           </th>
         }


### PR DESCRIPTION
Navigation ist wichtiger als eine Überschrift.

Könnte an NVDA liegen. @tjorbo Hast du Voiceover und kannst das einmal prüfen?
Das Thema existiert auch kaum, ich hab nur [diesen Kommentar](https://github.com/nvaccess/nvda/issues/8462#issuecomment-688324971) gefunden.