### PR TITLE
fix: set focus to relevant input after clicking time/end-date button

### DIFF
--- a/src/app/create-suggested-dates/create-suggested-dates.component.html
+++ b/src/app/create-suggested-dates/create-suggested-dates.component.html
@@ -218,7 +218,6 @@
                   {{ 'time.end' | translate }} ({{ 'time.placeholder' | translate }})
                 </label>
                 <input
-                  appAutoFocus
                   type="time"
                   id="suggested-date-end-time-{{i}}"
                   data-id="endTimeInput"
@@ -289,6 +288,7 @@
                 </label>
                 <input
                   appAutoFocus
+                  [autoFocus]="!getShowEndDateEndTimeControl(i) || getEndDateOfSuggestedStartDateByIndex(i).touched"
                   type="time"
                   id="suggested-date-start-time-{{i}}"
                   data-id="startTimeInputSecondColumn"
@@ -311,7 +311,6 @@
                   {{ 'time.end' | translate }} ({{ 'time.placeholder' | translate }})
                 </label>
                 <input
-                  appAutoFocus
                   type="time"
                   id="suggested-date-end-time-different-day-{{i}}"
                   data-id="endTimeInputSecondColumn"

--- a/src/app/shared/directives/autofocus.directive.ts
+++ b/src/app/shared/directives/autofocus.directive.ts
@@ -5,14 +5,16 @@ import {AfterContentInit, Directive, ElementRef, Input} from '@angular/core';
 })
 export class AutofocusDirective implements AfterContentInit {
 
-  @Input() public autoFocus: boolean;
+  @Input() public autoFocus: boolean = true;
 
   constructor(private el: ElementRef) {
   }
 
   public ngAfterContentInit(): void {
-    window.setTimeout(() => {
-      this.el.nativeElement.focus();
-    });
+    if (this.autoFocus) {
+      window.setTimeout(() => {
+        this.el.nativeElement.focus();
+      });
+    }
   }
 }


### PR DESCRIPTION
Add time button sets the focus to `startTime`.
Add endDate button sets the focus to `endDate`.

The directive 'appAutoFocus' didn't use its input variable `autoFocus`. Set default value and added if-block.

Removed directive from both `endTime` inputs.