### PR TITLE
refactor: checkbox text

### DIFF
--- a/src/app/shared/components/checkbox-field/checkbox-field.component.scss
+++ b/src/app/shared/components/checkbox-field/checkbox-field.component.scss
@@ -11,4 +11,5 @@ label {
 
 .multiline {
   white-space: pre-line;
+  vertical-align: text-bottom;
 }

--- a/src/app/shared/components/tos/tos.component.html
+++ b/src/app/shared/components/tos/tos.component.html
@@ -1,14 +1,19 @@
 <div class="form-row invalid-message-highlight">
   <div class="col section-container py-2 px-3">
-    <app-checkbox-field [formControl]="isTosRead" [labelTemplate]="tosLabelTemplate" ariaDescribedBy="tos-accept" [required]="'required'"/>
-
-    <ng-template #tosLabelTemplate>
+    <h2>{{ 'tos.header' | translate }}</h2>
+    <p>
       {{ 'tos.accept_0' | translate }}
       <a data-cy="tosPrivacyLink" routerLink="/privacy">{{ 'privacy.declaration' | translate }}</a>
       {{ 'tos.accept_1' | translate }}
       <a data-cy="tosLink" routerLink="/termsOfService">{{ 'tos.tos' | translate }}</a>
       {{ 'tos.accept_2' | translate }}
-    </ng-template>
+    </p>
+    <app-checkbox-field
+      [formControl]="isTosRead"
+      [label]="'tos.label' | translate"
+      ariaDescribedBy="tos-accept"
+      [required]="'required'"
+    />
 
     @if (isTosRead.dirty && isTosRead.invalid) {
       <div class="col-12 invalid-message" id="tos-accept" role="alert" aria-atomic="false">

--- a/src/app/shared/components/tos/tos.component.scss
+++ b/src/app/shared/components/tos/tos.component.scss
@@ -6,6 +6,11 @@ a {
   color: $primary;
 }
 
+h2,
+p {
+  font-size: $font-size-small !important;
+}
+
 .section-container {
   margin-bottom: 10px;
   @include media-breakpoint-up(lg) {

--- a/src/locales/de-DE-du.json
+++ b/src/locales/de-DE-du.json
@@ -262,7 +262,9 @@
     "accept_0": "Ich willige ein, dass die in der ",
     "accept_1": " genannte verantwortliche Stelle meine Daten zur Abstimmung von Besprechungsterminen verarbeitet, und weiß, dass ich diese Einwilligung jederzeit per E-Mail an die in der Datenschutzerklärung genannte Adresse der verantwortlichen Stelle mit Wirkung ausschließlich für die Zukunft widerrufen kann. Darüber hinaus stimme ich den ",
     "accept_2": " zu.",
-    "accept": "Bitte stimme den Nutzungsbedingungen zu und willige in die o.g. Datenverarbeitung ein."
+    "accept": "Bitte stimme den Nutzungsbedingungen zu und willige in die o.g. Datenverarbeitung ein.",
+    "header": "Datenschutz und Nutzungsbedingungen",
+    "label": "Ich stimme den Nutzungsbedingungen zu und willige in die o.g. Datenverarbeitung ein."
   },
   "footer": {
     "navLabel": {

--- a/src/locales/de-DE-sie.json
+++ b/src/locales/de-DE-sie.json
@@ -262,7 +262,9 @@
     "accept_0": "Ich willige ein, dass die in der ",
     "accept_1": " genannte verantwortliche Stelle meine Daten zur Abstimmung von Besprechungsterminen verarbeitet, und weiß, dass ich diese Einwilligung jederzeit per E-Mail an die in der Datenschutzerklärung genannte Adresse der verantwortlichen Stelle mit Wirkung ausschließlich für die Zukunft widerrufen kann. Darüber hinaus stimme ich den ",
     "accept_2": " zu.",
-    "accept": "Bitte stimme den Nutzungsbedingungen zu und willige in die o.g. Datenverarbeitung ein."
+    "accept": "Bitte stimme den Nutzungsbedingungen zu und willige in die o.g. Datenverarbeitung ein.",
+    "header": "Datenschutz und Nutzungsbedingungen",
+    "label": "Ich stimme den Nutzungsbedingungen zu und willige in die o.g. Datenverarbeitung ein."
   },
   "footer": {
     "navLabel": {

--- a/src/locales/en-EN.json
+++ b/src/locales/en-EN.json
@@ -262,7 +262,9 @@
     "accept_0": "I consent to the controller named in the ",
     "accept_1": " processing my data for the purpose of coordinating appointments and I know that I can revoke this consent at any time by sending an email to the address of the controller named in the privacy declaration with effect for the future only. Furthermore, I agree to the ",
     "accept_2": ".",
-    "accept": "Please agree to the terms of use and consent to the above data processing."
+    "accept": "Please agree to the terms of use and consent to the above data processing.",
+    "header": "Data processing and terms of use",
+    "label": "I agree to the terms of use and consent to the above data processing."
   },
   "footer": {
     "navLabel": {

--- a/src/locales/platt.json
+++ b/src/locales/platt.json
@@ -222,7 +222,9 @@
     "accept_0": "Ja, ick stimm to, datt de in de ",
     "accept_1": " benennte verantwörtliche Stee mien Daten to Affstimmung von Umfraagen verarbeiten dörf, und weet, datt ick de Inwilligung jedertiet per E-Mail an de in de Datenschutzerklärung benennte Adress von de verantwörtliche Stee mit Wirkung utschließlich för de Tukunft wedderroben kann. Doröber hinutt stimm ick de ",
     "accept_2": " to.",
-    "accept": "Bitte stimm de Datenschutzerklärung un de Bruukbedingen to."
+    "accept": "Bitte stimm de Datenschutzerklärung un de Bruukbedingen to.",
+    "header": "Datenschutz un Bruukbedingen",
+    "label": "Ick stimm de Datenschutzerklärung un de Bruukbedingen to."
   },
   "footer": {
     "navLabel": {


### PR DESCRIPTION
Put long checkbox text with links into an own container and give the actual checkbox a simple label. Navigation to the links was error-prone, as a slight shift in mouse/finger position activated the checkbox instead.
Added a heading to improve accessibility.