### PR TITLE
chore: update dependency `ngx-toastr`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "mediaelement": "^7.0.7",
         "moment": "2.30.1",
         "ngx-clipboard": "16.0.0",
-        "ngx-toastr": "^19.0.0",
+        "ngx-toastr": "19.1.0",
         "rxjs": "7.8.1",
         "tslib": "2.5.2",
         "zone.js": "0.14.10"
@@ -18101,9 +18101,9 @@
       }
     },
     "node_modules/ngx-toastr": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-19.0.0.tgz",
-      "integrity": "sha512-6pTnktwwWD+kx342wuMOWB4+bkyX9221pAgGz3SHOJH0/MI9erLucS8PeeJDFwbUYyh75nQ6AzVtolgHxi52dQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-19.1.0.tgz",
+      "integrity": "sha512-Qa7Kg7QzGKNtp1v04hu3poPKKx8BGBD/Onkhm6CdH5F0vSMdq+BdR/f8DTpZnGFksW891tAFufpiWb9UZX+3vg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -36262,9 +36262,9 @@
       }
     },
     "ngx-toastr": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-19.0.0.tgz",
-      "integrity": "sha512-6pTnktwwWD+kx342wuMOWB4+bkyX9221pAgGz3SHOJH0/MI9erLucS8PeeJDFwbUYyh75nQ6AzVtolgHxi52dQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-19.1.0.tgz",
+      "integrity": "sha512-Qa7Kg7QzGKNtp1v04hu3poPKKx8BGBD/Onkhm6CdH5F0vSMdq+BdR/f8DTpZnGFksW891tAFufpiWb9UZX+3vg==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "mediaelement": "^7.0.7",
     "moment": "2.30.1",
     "ngx-clipboard": "16.0.0",
-    "ngx-toastr": "^19.0.0",
+    "ngx-toastr": "19.1.0",
     "rxjs": "7.8.1",
     "tslib": "2.5.2",
     "zone.js": "0.14.10"


### PR DESCRIPTION
Version 19.0.1 & 19.0.2 are infected.

https://www.aikido.dev/blog/s1ngularity-nx-attackers-strike-again