### PR TITLE
build: set allowed scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,5 +98,15 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.60.0",
     "uuid": "14.0.0"
+  },
+  "allowScripts": {
+    "@parcel/watcher@2.5.6": true,
+    "core-js@3.49.0": true,
+    "cypress@15.16.0": true,
+    "esbuild@0.27.3": true,
+    "libxmljs2@0.37.0": true,
+    "lmdb@3.5.1": true,
+    "msgpackr-extract@3.0.4": true,
+    "unrs-resolver@1.12.2": true
   }
 }


### PR DESCRIPTION
`npm@12` will block installation scripts by default, this list enables needed scripts.