### PR TITLE
refactor: Allow crawling to read `noindex` headers

### DIFF
--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: /
+Allow: /


### PR DESCRIPTION
Some crawlers won't read headers/meta-tags like `noindex` when the access is blocked by `Disallow: /` in `robots.txt`